### PR TITLE
Fix typo mistake in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ resource "nexus_user" "admin" {
   email     = "nexus@example.com"
   password  = "admin123"
   roles     = ["nx-admin"]
-  status    = "online"
+  status    = "active"
 }
 ```
 


### PR DESCRIPTION
Small typo fix in documentation, possible values `active/disabled`
```shell
$ terraform apply

Error: expected status to be one of [active disabled], got online

  on main.tf line 12, in resource "nexus_user" "maven":
  12: resource "nexus_user" "maven" {
```