### PR TITLE
Add support for Helm repository

### DIFF
--- a/nexus/resource_repository.go
+++ b/nexus/resource_repository.go
@@ -23,7 +23,7 @@ func resourceRepository() *schema.Resource {
 				ForceNew:     true,
 				Required:     true,
 				Type:         schema.TypeString,
-				ValidateFunc: validation.StringInSlice([]string{"apt", "bower", "docker", "maven2", "nuget", "pypi"}, false),
+				ValidateFunc: validation.StringInSlice([]string{"apt", "bower", "docker", "maven2", "nuget", "pypi", "helm"}, false),
 			},
 			"name": {
 				Description: "A unique identifier for this repository",
@@ -46,7 +46,7 @@ func resourceRepository() *schema.Resource {
 			"apt": {
 				Type:          schema.TypeList,
 				Optional:      true,
-				ConflictsWith: []string{"bower", "docker", "docker_proxy", "maven"},
+				ConflictsWith: []string{"bower", "docker", "docker_proxy", "maven", "helm"},
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"distribution": {
@@ -59,7 +59,7 @@ func resourceRepository() *schema.Resource {
 			"apt_signing": {
 				Type:          schema.TypeList,
 				Optional:      true,
-				ConflictsWith: []string{"bower", "docker", "docker_proxy", "maven"},
+				ConflictsWith: []string{"bower", "docker", "docker_proxy", "maven", "helm"},
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"keypair": {
@@ -76,7 +76,7 @@ func resourceRepository() *schema.Resource {
 			"bower": {
 				Type:          schema.TypeList,
 				Optional:      true,
-				ConflictsWith: []string{"apt", "apt_signing", "docker", "docker_proxy", "maven"},
+				ConflictsWith: []string{"apt", "apt_signing", "docker", "docker_proxy", "maven", "helm"},
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"rewrite_package_urls": {
@@ -103,7 +103,7 @@ func resourceRepository() *schema.Resource {
 			"docker": {
 				Type:          schema.TypeList,
 				Optional:      true,
-				ConflictsWith: []string{"apt", "apt_signing", "bower", "maven"},
+				ConflictsWith: []string{"apt", "apt_signing", "bower", "maven", "helm"},
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"force_basic_auth": {
@@ -132,7 +132,7 @@ func resourceRepository() *schema.Resource {
 				},
 			},
 			"docker_proxy": {
-				ConflictsWith: []string{"apt", "apt_signing", "bower", "maven"},
+				ConflictsWith: []string{"apt", "apt_signing", "bower", "maven", "helm"},
 				Type:          schema.TypeList,
 				Optional:      true,
 				MaxItems:      1,


### PR DESCRIPTION
In the release of `Nexus 3.21.1` was added support for Helm repository so I would like to add it to Terraform provider

```shell
An execution plan has been generated and is shown below.
Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # nexus_repository.helm will be created
  + resource "nexus_repository" "helm" {
      + format = "helm"
      + id     = (known after apply)
      + name   = "helm"
      + online = true
      + type   = "hosted"

      + storage {
          + blob_store_name                = "default"
          + strict_content_type_validation = true
          + write_policy                   = "ALLOW_ONCE"
        }
    }

Plan: 1 to add, 0 to change, 0 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

nexus_repository.helm: Creating...
nexus_repository.helm: Creation complete after 0s [id=helm]

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.

```