### PR TITLE
Fix make darwin command

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -21,7 +21,7 @@ linux: fmtcheck
 	GCO_ENABLED=0 GOOS=linux GOARCH=amd64 $(GOBUILD) -o terraform.d/plugins/linux_amd64/terraform-provider-nexus -v
 
 darwin: fmtcheck
-	CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 $(GOBUILD) -o terraform.d/plugins/darwin_amd64/terraform-provider-nexus -v
+	CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 $(GOBUILD) -o ~/.terraform.d/plugins/darwin_amd64/terraform-provider-nexus -v
 
 test: fmtcheck
 	go test -i $(TEST) || exit 1


### PR DESCRIPTION
Currently make darwin command will build and save provider in current
folder, but to make it available in terraform it should be put under
home directory.

This patch changes output location to put binary in proper location.