### PR TITLE
Automatically build and publish releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,32 @@
+name: goreleaser
+
+on:
+  push:
+    branches:
+    - "!*"
+    tags:
+    - "v*"
+
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v2
+      -
+        name: Unshallow
+        run: git fetch --prune --unshallow
+      -
+        name: Set up Go
+        uses: actions/setup-go@v1
+        with:
+          go-version: 1.13.x
+      -
+        name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v1
+        with:
+          version: latest
+          args: release --rm-dist
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
         name: Set up Go
         uses: actions/setup-go@v1
         with:
-          go-version: 1.13.x
+          go-version: 1.14.x
       -
         name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v1

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,4 +1,5 @@
 build:
+  binary: terraform-provider-nexus_v{{ .Version }}
   goos:
   - darwin
   - linux
@@ -10,7 +11,7 @@ build:
 archives:
 # Terraform expects a "v" in the plugin version identifier
 - name_template: "{{ .ProjectName }}_v{{ .Version }}_{{ .Os }}_{{ .Arch }}"
-  format: gz
+  format: tar.gz
   format_overrides:
   - goos: windows
     format: zip

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,18 @@
+build:
+  goos:
+  - darwin
+  - linux
+  - windows
+  ignore:
+  - goos: darwin
+    goarch: 386
+
+archives:
+# Terraform expects a "v" in the plugin version identifier
+- name_template: "{{ .ProjectName }}_v{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+  format: gz
+  format_overrides:
+  - goos: windows
+    format: zip
+  files:
+  - none*

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 - [Introduction](#introduction)
 - [Usage](#usage)
-  - [Provider config](#provider-config
+  - [Provider config](#provider-config)
   - [Data Sources](#data-sources)
     - [nexus_blobstore](#nexus_blobstore)
     - [nexus_repository](#nexus_repository)


### PR DESCRIPTION
## what
Use [goreleaser](https://goreleaser.com) and GitHub actions to automatically publish `terraform-provider-nexus` binaries and change logs on every release. 

(Also fixes typo in README.md)

## why
Make the provider easily available for download as a Terraform plugin

## how
Every time a release is tagged, GitHub actions will be invoked to automatically build and publish the artifacts. 

A user can then install the plugin with something like
```
cd ~/.terraform.d/plugins/linux_amd64
curl -sSL https://github.com/datadrivers/terraform-provider-nexus/releases/download/v1.2.1/terraform-provider-nexus_v1.2.1_linux_amd64.tar.gz | tar xzv
```