### PR TITLE
fix(go): remove TYPO so linux is build statically too

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -24,7 +24,7 @@ build: fmtcheck
 	go build -v .
 
 linux: fmtcheck
-	GCO_ENABLED=0 GOOS=linux GOARCH=amd64 $(GOBUILD) -o terraform.d/plugins/linux_amd64/terraform-provider-nexus -v
+	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 $(GOBUILD) -o terraform.d/plugins/linux_amd64/terraform-provider-nexus -v
 
 darwin: fmtcheck
 	CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 $(GOBUILD) -o terraform.d/plugins/darwin_amd64/terraform-provider-nexus -v


### PR DESCRIPTION
probably fixes `.terraform.d/plugins/linux_amd64/terraform-provider-: No such file or directory` error