### PR TITLE
Update .goreleaser.yml with the one from scaffolding repo

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,25 +1,54 @@
-build:
-  binary: terraform-provider-nexus_v{{ .Version }}
-  env:
-    - CGO_ENABLED=0 # force static builds
+# Visit https://goreleaser.com for documentation on how to customize this
+# behavior.
+before:
+  hooks:
+    # this is just an example and not a requirement for provider building/publishing
+    - go mod tidy
+builds:
+- env:
+    # goreleaser does not work with CGO, it could also complicate
+    # usage by users in CI/CD systems like Terraform Cloud where
+    # they are unable to install libraries.
+    - CGO_ENABLED=0
+  mod_timestamp: '{{ .CommitTimestamp }}'
+  flags:
+    - -trimpath
+  ldflags:
+    - '-s -w -X main.version={{.Version}} -X main.commit={{.Commit}}'
   goos:
-  - darwin
-  - linux
-  - windows
+    - freebsd
+    - windows
+    - linux
+    - darwin
+  goarch:
+    - amd64
+    - '386'
+    - arm
+    - arm64
   ignore:
-  - goos: darwin
-    goarch: 386
-
+    - goos: darwin
+      goarch: '386'
+  binary: '{{ .ProjectName }}_v{{ .Version }}'
 archives:
-# Terraform expects a "v" in the plugin version identifier
-- name_template: "{{ .ProjectName }}_v{{ .Version }}_{{ .Os }}_{{ .Arch }}"
-  format: tar.gz
-  format_overrides:
-  - goos: windows
-    format: zip
-  files:
-  - none*
-
+- format: zip
+  name_template: '{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}'
+checksum:
+  name_template: '{{ .ProjectName }}_{{ .Version }}_SHA256SUMS'
+  algorithm: sha256
 signs:
   - artifacts: checksum
-    args: ["--batch", "-u", "{{ .Env.GPG_FINGERPRINT }}", "--output", "${signature}", "--detach-sign", "${artifact}"]
+    args:
+      # if you are using this is a GitHub action or some other automated pipeline, you 
+      # need to pass the batch flag to indicate its not interactive.
+      - "--batch"
+      - "--local-user"
+      - "{{ .Env.GPG_FINGERPRINT }}" # set this environment variable for your signing key
+      - "--output"
+      - "${signature}"
+      - "--detach-sign"
+      - "${artifact}"
+release:
+  # If you want to manually examine the release before its live, uncomment this line:
+  # draft: true
+changelog:
+  skip: true


### PR DESCRIPTION
The Terraform Registry expects the archives to be named in a certain way which is needed for #76 

While I was on it, I copied the whole `.goreleaser.yml` file [from the scaffolding repo](https://github.com/hashicorp/terraform-provider-scaffolding/blob/master/.goreleaser.yml).