### PR TITLE
Update go-nexus-client to support proxy config from environment variables

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -10,7 +10,7 @@ description: |-
   
 The Nexus provider allows Terraform to read from, write to, and configure [Sonatype Nexus Repository Manager](https://www.sonatype.com/product-nexus-repository).
 
--> **Note** This provider hat been implemented and tested with Sonatype Nexus Repository Manager OSS `3.26.1-02`.
+-> **Note** This provider hat been implemented and tested with Sonatype Nexus Repository Manager OSS `3.29.0-02`.
 
 ## Usage
 
@@ -33,61 +33,6 @@ The following arguments are supported:
 * `password`  - (Required) Password of user to connect to API.
 * `url`       - (Required) URL of Nexus to reach API.
 * `usernamme` - (Required) Username used to connect to API.
-
-## Build
-
-There is a [makefile](./GNUmakefile) to build the provider.
-
-```sh
-make
-```
-
-To build and install provider on macOS into `~/.terraform.d/plugins/darwin_amd64`, you can run
-
-```sh
-make darwin-build-install
-```
-
-In this case provider will be available to use with your terraform codebase (in terraform init stage).
-
-## Testing
-
-For testing start a local Docker containers using make
-
-```shell
-make start-services
-```
-
-This will start a Docker and MinIO containers and expose ports 8081 and 9000.
-
-Now start the tests
-
-```shell
-NEXUS_URL="http://127.0.0.1:8081" NEXUS_USERNAME="admin" NEXUS_PASSWORD="admin123" AWS_ACCESS_KEY_ID="minioadmin" AWS_SECRET_ACCESS_KEY="minioadmin" AWS_ENDPOINT="http://minio:9000" make testacc
-```
-
-or without S3 tests:
-
-```shell
-SKIP_S3_TESTS=1 NEXUS_URL="http://127.0.0.1:8081" NEXUS_USERNAME="admin" NEXUS_PASSWORD="admin123" make testacc
-```
-
-**NOTE**: To test Blobstore type S3 following environment variables must be set, otherwise tests will fail:
-
-- `AWS_ACCESS_KEY_ID`,
-- `AWS_SECRET_ACCESS_KEY`,
-- `AWS_DEFAULT_REGION` the AWS region of the S3 bucket to use, defaults to `eu-central-1`,
-- `AWS_BUCKET_NAME` the name of S3 bucket to use, defaults to `terraform-provider-nexus-s3-test`.
-
-Optionally you can set `AWS_ENDPOINT` to point an alternative S3 endpoint.
-
-To debug tests
-
-Set env variable `TF_LOG=DEBUG` to see additional output.
-
-Use `printState()` function to discover terraform state (and resource props) during test.
-
-Debug configurations are also available for VS Code.
 
 ## Author
 

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/datadrivers/terraform-provider-nexus
 go 1.14
 
 require (
-	github.com/datadrivers/go-nexus-client v0.16.0
+	github.com/datadrivers/go-nexus-client v0.17.0
 	github.com/hashicorp/terraform-plugin-sdk v1.15.0
 	github.com/stretchr/testify v1.6.1
 )

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/datadrivers/terraform-provider-nexus
 go 1.14
 
 require (
-	github.com/datadrivers/go-nexus-client v0.17.0
+	github.com/datadrivers/go-nexus-client v0.17.1
 	github.com/hashicorp/terraform-plugin-sdk v1.15.0
 	github.com/stretchr/testify v1.6.1
 )

--- a/go.sum
+++ b/go.sum
@@ -32,8 +32,8 @@ github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kB
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cheggaaa/pb v1.0.27/go.mod h1:pQciLPpbU0oxA0h+VJYYLxO+XeDQb5pZijXscXHm81s=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
-github.com/datadrivers/go-nexus-client v0.16.0 h1:5RtgT6iV8B0AHubtFj8PJQ8L4xQtmCO8AXiap3DhYMo=
-github.com/datadrivers/go-nexus-client v0.16.0/go.mod h1:bN9cSUGOSYdMSiLypohV+Uq3JKpW/gCkRlkk1jFJJ+s=
+github.com/datadrivers/go-nexus-client v0.17.1 h1:hCTL62h1flYeDK+KrPdGiNxtGn7e1D43LJ0ahOguIN8=
+github.com/datadrivers/go-nexus-client v0.17.1/go.mod h1:bN9cSUGOSYdMSiLypohV+Uq3JKpW/gCkRlkk1jFJJ+s=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=


### PR DESCRIPTION
works after merging datadrivers/go-nexus-client#48
this support #90.