### PR TITLE
chore(testing): added minikube mount to be able to use mount files

### DIFF
--- a/.github/workflows/feature-branches.yaml
+++ b/.github/workflows/feature-branches.yaml
@@ -17,12 +17,6 @@ jobs:
       - name: Test client with nexus3 instance
         env:
           NEXUS3_LICENSE_B64_ENCODED: ${{ secrets.NEXUS3_LICENSE_B64_ENCODED }}
-          NEXUS_URL: http://127.0.0.1:8081
-          NEXUS_USERNAME: admin
-          NEXUS_PASSWORD: admin123
-          AWS_ACCESS_KEY_ID: "minioadmin"
-          AWS_SECRET_ACCESS_KEY: "minioadmin"
-          AWS_ENDPOINT: "http://minio:9000"
         run: |
           echo "${NEXUS3_LICENSE_B64_ENCODED}" | base64 -d > scripts/license.lic
           make start-services

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -12,12 +12,25 @@ GOFMT_FILES?=$$(find . -name '*.go' | grep -v vendor)
 
 WEBSITE_REPO=github.com/hashicorp/terraform-website
 
+NEXUS_HOST=$(shell cd ./scripts && ./detect-docker-env-ip.sh)
+MINIO_HOST=$(shell if [ "$(NEXUS_HOST)" = "127.0.0.1" ]; then echo "minio"; else echo "$(NEXUS_HOST)"; fi;)
+NEXUS_PORT=$(shell grep -E "(NEXUS_PORT=)" ./scripts/.env | grep -oE "[0-9]+")
+MINIKUBE_MOUNT_PID=$(word 1,$(shell ps | grep -v grep | grep 'minikube mount' | grep $(PWD)/scripts))
+
 default: build
 
 start-services:
+ifeq (minikube,$(MINIKUBE_ACTIVE_DOCKERD))
+ifeq (,$(MINIKUBE_MOUNT_PID))
+	minikube mount $(PWD)/scripts:$(PWD)/scripts --uid=200 --gid=200 &
+endif
+endif
 	cd ./scripts && ./start-services.sh && cd -
 
 stop-services:
+ifneq (,$(MINIKUBE_MOUNT_PID))
+	kill $(MINIKUBE_MOUNT_PID)
+endif
 	cd ./scripts && ./stop-services.sh && cd -
 
 build: fmtcheck
@@ -38,6 +51,12 @@ test: fmtcheck
 		xargs -t -n4 go test -cover $(TESTARGS) -timeout=30s -parallel=4
 
 testacc: fmtcheck
+	NEXUS_URL="http://$(NEXUS_HOST):$(NEXUS_PORT)" \
+	NEXUS_USERNAME="admin" \
+	NEXUS_PASSWORD="admin123" \
+	AWS_ACCESS_KEY_ID="minioadmin" \
+	AWS_SECRET_ACCESS_KEY="minioadmin" \
+	AWS_ENDPOINT="http://$(MINIO_HOST):9000" \
 	TF_ACC=1 go test $(TEST) -v $(TESTARGS) -cover -timeout 120m -parallel=4
 
 vet:

--- a/README.md
+++ b/README.md
@@ -95,25 +95,16 @@ This will start a Docker and MinIO containers and expose ports 8081 and 9000.
 Now start the tests
 
 ```shell
-NEXUS_URL="http://127.0.0.1:8081" NEXUS_USERNAME="admin" NEXUS_PASSWORD="admin123" AWS_ACCESS_KEY_ID="minioadmin" AWS_SECRET_ACCESS_KEY="minioadmin" AWS_ENDPOINT="http://minio:9000" make testacc
+make testacc
 ```
 
 or without S3 tests:
 
 ```shell
-SKIP_S3_TESTS=1 NEXUS_URL="http://127.0.0.1:8081" NEXUS_USERNAME="admin" NEXUS_PASSWORD="admin123" make testacc
+SKIP_S3_TESTS=1 make testacc
 ```
 
-**NOTE**: To test Blobstore type S3 following environment variables must be set, otherwise tests will fail:
-
-- `AWS_ACCESS_KEY_ID`,
-- `AWS_SECRET_ACCESS_KEY`,
-- `AWS_DEFAULT_REGION` the AWS region of the S3 bucket to use, defaults to `eu-central-1`,
-- `AWS_BUCKET_NAME` the name of S3 bucket to use, defaults to `terraform-provider-nexus-s3-test`.
-
-Optionally you can set `AWS_ENDPOINT` to point an alternative S3 endpoint.
-
-To debug tests
+#### To debug tests
 
 Set env variable `TF_LOG=DEBUG` to see additional output.
 

--- a/scripts/detect-docker-env-ip.sh
+++ b/scripts/detect-docker-env-ip.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env sh
+set +e
+
+IP="127.0.0.1"
+
+if command -v minikube >/dev/null; then
+  dockerEnv=$(minikube status -f '{{- if .DockerEnv }}{{.DockerEnv}}{{- end }}')
+  if [ $? -eq 0 ]; then
+    if [ "${dockerEnv}" = "in-use" ]; then
+      IP=$(minikube ip)
+    fi
+  fi
+fi
+
+echo ${IP}

--- a/scripts/docker-compose.yml
+++ b/scripts/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     ports:
       - "${NEXUS_PORT}:8081"
     volumes:
-      - "${PWD}/oss-nexus.properties:/nexus-data/etc/nexus.properties"
+      - "${PWD}/oss-nexus.properties:/nexus-data/etc/nexus.properties:ro"
     profiles:
       - oss
   nexus-pro:
@@ -13,15 +13,15 @@ services:
     ports:
       - "${NEXUS_PORT}:8081"
     volumes:
-      - "${PWD}/pro-nexus.properties:/nexus-data/etc/nexus.properties"
-      - "${PWD}/license.lic:/nexus-data/etc/license.lic"
+      - "${PWD}/pro-nexus.properties:/nexus-data/etc/nexus.properties:ro"
+      - "${PWD}/license.lic:/nexus-data/etc/license.lic:ro"
     profiles:
       - pro
   minio:
     image: "minio/minio:latest"
     ports:
       - "9000:9000"
-    command: "server /data"
+    command: "server --address :9000 /data"
     environment:
       - MINIO_ACCESS_KEY=minioadmin
       - MINIO_SECRET_KEY=minioadmin

--- a/scripts/wait-for-nexus.sh
+++ b/scripts/wait-for-nexus.sh
@@ -3,18 +3,7 @@ set -eo pipefail
 
 source .env
 
-IP="127.0.0.1"
-
-if command -v minikube; then
-  set +e
-  dockerEnv=$(minikube status -f '{{- if .DockerEnv }}{{.DockerEnv}}{{- end }}')
-  if [[ $? -eq 0 ]]; then
-    if [[ "${dockerEnv}" == "in-use" ]]; then
-      IP=$(minikube ip)
-    fi
-  fi
-  set -e
-fi
+IP=$(./detect-docker-env-ip.sh)
 
 if command -v wget; then
   checkcmd="wget -t 1 http://${IP}:${NEXUS_PORT} -O /dev/null -q"


### PR DESCRIPTION
- added variables for testing to GNUMakefile instead of setting it 
manually
- set in docker-compose license and properties file to be Read-Only 
mounted
- set minio port bind to :9000 explicitly, to be able to use minikube
- extracted NEXUS_IP to be detected from extra script, and reused 
everywhere
