### PR TITLE
chore(dependabot): added dependabot for updating go_modules, gh-actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: daily
+  - package-ecosystem: go_modules
+    directory: /
+    schedule:
+      interval: daily


### PR DESCRIPTION
https://github.com/dependabot
will create PRs and we can decide to update easily