### PR TITLE
chore: Update logging to legacy logging with support for levels

### DIFF
--- a/internal/services/blobstore/resource_blobstore_azure.go
+++ b/internal/services/blobstore/resource_blobstore_azure.go
@@ -129,7 +129,7 @@ func resourceBlobstoreAzureRead(resourceData *schema.ResourceData, m interface{}
 	nexusClient := m.(*nexus.NexusClient)
 
 	bs, err := nexusClient.BlobStore.Azure.Get(resourceData.Id())
-	log.Print(bs)
+	log.Printf("[DEBUG] BlobStore:\n%+v\n", bs)
 	if err != nil {
 		return err
 	}

--- a/internal/services/blobstore/resource_blobstore_file.go
+++ b/internal/services/blobstore/resource_blobstore_file.go
@@ -83,7 +83,7 @@ func resourceBlobstoreFileRead(resourceData *schema.ResourceData, m interface{})
 	nexusClient := m.(*nexus.NexusClient)
 
 	bs, err := nexusClient.BlobStore.File.Get(resourceData.Id())
-	log.Print(bs)
+	log.Printf("[DEBUG] BlobStore:\n%+v\n", bs)
 	if err != nil {
 		return err
 	}

--- a/internal/services/blobstore/resource_blobstore_group.go
+++ b/internal/services/blobstore/resource_blobstore_group.go
@@ -95,7 +95,7 @@ func resourceBlobstoreGroupRead(resourceData *schema.ResourceData, m interface{}
 	nexusClient := m.(*nexus.NexusClient)
 
 	bs, err := nexusClient.BlobStore.Group.Get(resourceData.Id())
-	log.Print(bs)
+	log.Printf("[DEBUG] BlobStore:\n%+v\n", bs)
 	if err != nil {
 		return err
 	}

--- a/internal/services/blobstore/resource_blobstore_s3.go
+++ b/internal/services/blobstore/resource_blobstore_s3.go
@@ -249,7 +249,7 @@ func resourceBlobstoreS3Read(resourceData *schema.ResourceData, m interface{}) e
 	nexusClient := m.(*nexus.NexusClient)
 
 	bs, err := nexusClient.BlobStore.S3.Get(resourceData.Id())
-	log.Print(bs)
+	log.Printf("[DEBUG] BlobStore:\n%+v\n", bs)
 	if err != nil {
 		return err
 	}

--- a/internal/services/deprecated/resource_blobstore.go
+++ b/internal/services/deprecated/resource_blobstore.go
@@ -313,7 +313,7 @@ func resourceBlobstoreRead(d *schema.ResourceData, m interface{}) error {
 	client := m.(*nexus.NexusClient)
 
 	bs, err := client.BlobStore.Legacy.Get(d.Id())
-	log.Print(bs)
+	log.Printf("[DEBUG] BlobStore:\n%+v\n", bs)
 	if err != nil {
 		return err
 	}

--- a/main.go
+++ b/main.go
@@ -18,13 +18,17 @@ func main() {
 	flag.BoolVar(&debugMode, "debuggable", false, "set to true to run the provider with support for debuggers like delve")
 	flag.Parse()
 
+	// Clean up log output
+	// See https://developer.hashicorp.com/terraform/plugin/log/writing#legacy-logging
+	log.SetFlags(log.Flags() &^ (log.Ldate | log.Ltime))
+
 	if debugMode {
 		err := plugin.Debug(context.Background(), "registry.terraform.io/datadrivers/nexus",
 			&plugin.ServeOpts{
 				ProviderFunc: provider.Provider,
 			})
 		if err != nil {
-			log.Println(err.Error())
+			log.Printf("[ERROR] Error during initialization: %s", err.Error())
 		}
 	} else {
 		plugin.Serve(&plugin.ServeOpts{


### PR DESCRIPTION
The current logging is not configured, leading to double timestamps and Terraform not recognizing log levels. This PR adds the proper configuration and modifies existing log calls.

See https://developer.hashicorp.com/terraform/plugin/log/writing#legacy-logging