### PR TITLE
Fix resource group members ordering

### DIFF
--- a/internal/schema/repository/schema_group.go
+++ b/internal/schema/repository/schema_group.go
@@ -1,8 +1,6 @@
 package repository
 
 import (
-	"strings"
-
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
@@ -18,10 +16,7 @@ var (
 					},
 					MinItems: 1,
 					Required: true,
-					Set: func(v interface{}) int {
-						return schema.HashString(strings.ToLower(v.(string)))
-					},
-					Type: schema.TypeSet,
+					Type:     schema.TypeList,
 				},
 			},
 		},
@@ -40,10 +35,7 @@ var (
 					},
 					MinItems: 1,
 					Required: true,
-					Set: func(v interface{}) int {
-						return schema.HashString(strings.ToLower(v.(string)))
-					},
-					Type: schema.TypeSet,
+					Type:     schema.TypeList,
 				},
 				"writable_member": {
 					Description: "Pro-only: This field is for the Group Deployment feature available in NXRM Pro.",
@@ -66,7 +58,7 @@ var (
 						Type: schema.TypeString,
 					},
 					Computed: true,
-					Type:     schema.TypeSet,
+					Type:     schema.TypeList,
 				},
 			},
 		},
@@ -83,7 +75,7 @@ var (
 						Type: schema.TypeString,
 					},
 					Computed: true,
-					Type:     schema.TypeSet,
+					Type:     schema.TypeList,
 				},
 				"writable_member": {
 					Description: "Pro-only: This field is for the Group Deployment feature available in NXRM Pro.",

--- a/internal/services/repository/data_source_repository_raw_group_test.go
+++ b/internal/services/repository/data_source_repository_raw_group_test.go
@@ -19,7 +19,8 @@ data "nexus_repository_raw_group" "acceptance" {
 }
 
 func TestAccDataSourceRepositoryRawGroup(t *testing.T) {
-	repoHosted := testAccResourceRepositoryRawHosted()
+	repoHostedFirst := testAccResourceRepositoryRawHosted()
+	repoHostedSecond := testAccResourceRepositoryRawHosted()
 	repoGroup := repository.RawGroupRepository{
 		Name:   fmt.Sprintf("acceptance-%s", acctest.RandString(10)),
 		Online: true,
@@ -28,7 +29,10 @@ func TestAccDataSourceRepositoryRawGroup(t *testing.T) {
 			StrictContentTypeValidation: false,
 		},
 		Group: repository.Group{
-			MemberNames: []string{repoHosted.Name},
+			MemberNames: []string{
+				repoHostedFirst.Name,
+				repoHostedSecond.Name,
+			},
 		},
 	}
 	dataSourceName := "data.nexus_repository_raw_group.acceptance"
@@ -38,7 +42,7 @@ func TestAccDataSourceRepositoryRawGroup(t *testing.T) {
 		Providers: acceptance.TestAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccResourceRepositoryRawHostedConfig(repoHosted) + testAccResourceRepositoryRawGroupConfig(repoGroup) + testAccDataSourceRepositoryRawGroupConfig(),
+				Config: testAccResourceRepositoryRawHostedConfig(repoHostedFirst) + testAccResourceRepositoryRawHostedConfig(repoHostedSecond) + testAccResourceRepositoryRawGroupConfig(repoGroup) + testAccDataSourceRepositoryRawGroupConfig(),
 				Check: resource.ComposeTestCheckFunc(
 					resource.ComposeAggregateTestCheckFunc(
 						resource.ComposeAggregateTestCheckFunc(

--- a/internal/services/repository/resource_repository_bower_group.go
+++ b/internal/services/repository/resource_repository_bower_group.go
@@ -37,7 +37,7 @@ func getBowerGroupRepositoryFromResourceData(resourceData *schema.ResourceData) 
 	storageConfig := resourceData.Get("storage").([]interface{})[0].(map[string]interface{})
 	groupConfig := resourceData.Get("group").([]interface{})[0].(map[string]interface{})
 	groupMemberNames := []string{}
-	for _, name := range groupConfig["member_names"].(*schema.Set).List() {
+	for _, name := range groupConfig["member_names"].([]interface{}) {
 		groupMemberNames = append(groupMemberNames, name.(string))
 	}
 

--- a/internal/services/repository/resource_repository_docker_group.go
+++ b/internal/services/repository/resource_repository_docker_group.go
@@ -41,7 +41,7 @@ func getDockerGroupRepositoryFromResourceData(resourceData *schema.ResourceData)
 	dockerConfig := resourceData.Get("docker").([]interface{})[0].(map[string]interface{})
 	groupConfig := resourceData.Get("group").([]interface{})[0].(map[string]interface{})
 	groupMemberNames := []string{}
-	for _, name := range groupConfig["member_names"].(*schema.Set).List() {
+	for _, name := range groupConfig["member_names"].([]interface{}) {
 		groupMemberNames = append(groupMemberNames, name.(string))
 	}
 

--- a/internal/services/repository/resource_repository_go_group.go
+++ b/internal/services/repository/resource_repository_go_group.go
@@ -37,7 +37,7 @@ func getGoGroupRepositoryFromResourceData(resourceData *schema.ResourceData) rep
 	storageConfig := resourceData.Get("storage").([]interface{})[0].(map[string]interface{})
 	groupConfig := resourceData.Get("group").([]interface{})[0].(map[string]interface{})
 	groupMemberNames := []string{}
-	for _, name := range groupConfig["member_names"].(*schema.Set).List() {
+	for _, name := range groupConfig["member_names"].([]interface{}) {
 		groupMemberNames = append(groupMemberNames, name.(string))
 	}
 

--- a/internal/services/repository/resource_repository_maven_group.go
+++ b/internal/services/repository/resource_repository_maven_group.go
@@ -37,10 +37,9 @@ func getMavenGroupRepositoryFromResourceData(resourceData *schema.ResourceData) 
 	storageConfig := resourceData.Get("storage").([]interface{})[0].(map[string]interface{})
 	groupConfig := resourceData.Get("group").([]interface{})[0].(map[string]interface{})
 	groupMemberNames := []string{}
-	for _, name := range groupConfig["member_names"].(*schema.Set).List() {
+	for _, name := range groupConfig["member_names"].([]interface{}) {
 		groupMemberNames = append(groupMemberNames, name.(string))
 	}
-
 	repo := repository.MavenGroupRepository{
 		Name:   resourceData.Get("name").(string),
 		Online: resourceData.Get("online").(bool),

--- a/internal/services/repository/resource_repository_npm_group.go
+++ b/internal/services/repository/resource_repository_npm_group.go
@@ -38,7 +38,7 @@ func getNpmGroupRepositoryFromResourceData(resourceData *schema.ResourceData) re
 	storageConfig := resourceData.Get("storage").([]interface{})[0].(map[string]interface{})
 	groupConfig := resourceData.Get("group").([]interface{})[0].(map[string]interface{})
 	groupMemberNames := []string{}
-	for _, name := range groupConfig["member_names"].(*schema.Set).List() {
+	for _, name := range groupConfig["member_names"].([]interface{}) {
 		groupMemberNames = append(groupMemberNames, name.(string))
 	}
 

--- a/internal/services/repository/resource_repository_nuget_group.go
+++ b/internal/services/repository/resource_repository_nuget_group.go
@@ -37,7 +37,7 @@ func getNugetGroupRepositoryFromResourceData(resourceData *schema.ResourceData) 
 	storageConfig := resourceData.Get("storage").([]interface{})[0].(map[string]interface{})
 	groupConfig := resourceData.Get("group").([]interface{})[0].(map[string]interface{})
 	groupMemberNames := []string{}
-	for _, name := range groupConfig["member_names"].(*schema.Set).List() {
+	for _, name := range groupConfig["member_names"].([]interface{}) {
 		groupMemberNames = append(groupMemberNames, name.(string))
 	}
 

--- a/internal/services/repository/resource_repository_pypi_group.go
+++ b/internal/services/repository/resource_repository_pypi_group.go
@@ -37,7 +37,7 @@ func getPypiGroupRepositoryFromResourceData(resourceData *schema.ResourceData) r
 	storageConfig := resourceData.Get("storage").([]interface{})[0].(map[string]interface{})
 	groupConfig := resourceData.Get("group").([]interface{})[0].(map[string]interface{})
 	groupMemberNames := []string{}
-	for _, name := range groupConfig["member_names"].(*schema.Set).List() {
+	for _, name := range groupConfig["member_names"].([]interface{}) {
 		groupMemberNames = append(groupMemberNames, name.(string))
 	}
 

--- a/internal/services/repository/resource_repository_r_group.go
+++ b/internal/services/repository/resource_repository_r_group.go
@@ -37,7 +37,7 @@ func getRGroupRepositoryFromResourceData(resourceData *schema.ResourceData) repo
 	storageConfig := resourceData.Get("storage").([]interface{})[0].(map[string]interface{})
 	groupConfig := resourceData.Get("group").([]interface{})[0].(map[string]interface{})
 	groupMemberNames := []string{}
-	for _, name := range groupConfig["member_names"].(*schema.Set).List() {
+	for _, name := range groupConfig["member_names"].([]interface{}) {
 		groupMemberNames = append(groupMemberNames, name.(string))
 	}
 

--- a/internal/services/repository/resource_repository_raw_group.go
+++ b/internal/services/repository/resource_repository_raw_group.go
@@ -37,7 +37,7 @@ func getRawGroupRepositoryFromResourceData(resourceData *schema.ResourceData) re
 	storageConfig := resourceData.Get("storage").([]interface{})[0].(map[string]interface{})
 	groupConfig := resourceData.Get("group").([]interface{})[0].(map[string]interface{})
 	groupMemberNames := []string{}
-	for _, name := range groupConfig["member_names"].(*schema.Set).List() {
+	for _, name := range groupConfig["member_names"].([]interface{}) {
 		groupMemberNames = append(groupMemberNames, name.(string))
 	}
 

--- a/internal/services/repository/resource_repository_rubygems_group.go
+++ b/internal/services/repository/resource_repository_rubygems_group.go
@@ -37,7 +37,7 @@ func getRubygemsGroupRepositoryFromResourceData(resourceData *schema.ResourceDat
 	storageConfig := resourceData.Get("storage").([]interface{})[0].(map[string]interface{})
 	groupConfig := resourceData.Get("group").([]interface{})[0].(map[string]interface{})
 	groupMemberNames := []string{}
-	for _, name := range groupConfig["member_names"].(*schema.Set).List() {
+	for _, name := range groupConfig["member_names"].([]interface{}) {
 		groupMemberNames = append(groupMemberNames, name.(string))
 	}
 

--- a/internal/services/repository/resource_repository_yum_group.go
+++ b/internal/services/repository/resource_repository_yum_group.go
@@ -40,7 +40,7 @@ func getYumGroupRepositoryFromResourceData(resourceData *schema.ResourceData) re
 	storageConfig := resourceData.Get("storage").([]interface{})[0].(map[string]interface{})
 	groupConfig := resourceData.Get("group").([]interface{})[0].(map[string]interface{})
 	groupMemberNames := []string{}
-	for _, name := range groupConfig["member_names"].(*schema.Set).List() {
+	for _, name := range groupConfig["member_names"].([]interface{}) {
 		groupMemberNames = append(groupMemberNames, name.(string))
 	}
 


### PR DESCRIPTION
Fixes: https://github.com/datadrivers/terraform-provider-nexus/issues/339

Repository groups are not Lists so the ordering is not honored. This switches to lists and adds a test to ensure that it works. 