### PR TITLE
fix: routing_rules refresh

### DIFF
--- a/internal/services/repository/resource_repository_apt_proxy.go
+++ b/internal/services/repository/resource_repository_apt_proxy.go
@@ -184,6 +184,13 @@ func resourceAptProxyRepositoryRead(resourceData *schema.ResourceData, m interfa
 		return nil
 	}
 
+	expectedRoutingRule := resourceData.Get("routing_rule").(string)
+	if repo.RoutingRule != nil && *repo.RoutingRule != expectedRoutingRule {
+		resourceData.Set("routing_rule", *repo.RoutingRule)
+	} else if repo.RoutingRule == nil {
+		resourceData.Set("routing_rule", nil)
+	}
+
 	return setAptProxyRepositoryToResourceData(repo, resourceData)
 }
 

--- a/internal/services/repository/resource_repository_bower_proxy.go
+++ b/internal/services/repository/resource_repository_bower_proxy.go
@@ -162,6 +162,13 @@ func resourceBowerProxyRepositoryCreate(resourceData *schema.ResourceData, m int
 	}
 	resourceData.SetId(repo.Name)
 
+	expectedRoutingRule := resourceData.Get("routing_rule").(string)
+	if repo.RoutingRule != nil && *repo.RoutingRule != expectedRoutingRule {
+		resourceData.Set("routing_rule", *repo.RoutingRule)
+	} else if repo.RoutingRule == nil {
+		resourceData.Set("routing_rule", nil)
+	}
+
 	return resourceBowerProxyRepositoryRead(resourceData, m)
 }
 

--- a/internal/services/repository/resource_repository_cocoapods_proxy.go
+++ b/internal/services/repository/resource_repository_cocoapods_proxy.go
@@ -167,6 +167,13 @@ func resourceCocoapodsProxyRepositoryRead(resourceData *schema.ResourceData, m i
 		return nil
 	}
 
+	expectedRoutingRule := resourceData.Get("routing_rule").(string)
+	if repo.RoutingRule != nil && *repo.RoutingRule != expectedRoutingRule {
+		resourceData.Set("routing_rule", *repo.RoutingRule)
+	} else if repo.RoutingRule == nil {
+		resourceData.Set("routing_rule", nil)
+	}
+
 	return setCocoapodsProxyRepositoryToResourceData(repo, resourceData)
 }
 

--- a/internal/services/repository/resource_repository_conan_proxy.go
+++ b/internal/services/repository/resource_repository_conan_proxy.go
@@ -167,6 +167,13 @@ func resourceConanProxyRepositoryRead(resourceData *schema.ResourceData, m inter
 		return nil
 	}
 
+	expectedRoutingRule := resourceData.Get("routing_rule").(string)
+	if repo.RoutingRule != nil && *repo.RoutingRule != expectedRoutingRule {
+		resourceData.Set("routing_rule", *repo.RoutingRule)
+	} else if repo.RoutingRule == nil {
+		resourceData.Set("routing_rule", nil)
+	}
+
 	return setConanProxyRepositoryToResourceData(repo, resourceData)
 }
 

--- a/internal/services/repository/resource_repository_conda_proxy.go
+++ b/internal/services/repository/resource_repository_conda_proxy.go
@@ -167,6 +167,13 @@ func resourceCondaProxyRepositoryRead(resourceData *schema.ResourceData, m inter
 		return nil
 	}
 
+	expectedRoutingRule := resourceData.Get("routing_rule").(string)
+	if repo.RoutingRule != nil && *repo.RoutingRule != expectedRoutingRule {
+		resourceData.Set("routing_rule", *repo.RoutingRule)
+	} else if repo.RoutingRule == nil {
+		resourceData.Set("routing_rule", nil)
+	}
+
 	return setCondaProxyRepositoryToResourceData(repo, resourceData)
 }
 

--- a/internal/services/repository/resource_repository_docker_proxy.go
+++ b/internal/services/repository/resource_repository_docker_proxy.go
@@ -234,6 +234,13 @@ func resourceDockerProxyRepositoryRead(resourceData *schema.ResourceData, m inte
 		return nil
 	}
 
+	expectedRoutingRule := resourceData.Get("routing_rule").(string)
+	if repo.RoutingRule != nil && *repo.RoutingRule != expectedRoutingRule {
+		resourceData.Set("routing_rule", *repo.RoutingRule)
+	} else if repo.RoutingRule == nil {
+		resourceData.Set("routing_rule", nil)
+	}
+
 	return setDockerProxyRepositoryToResourceData(repo, resourceData)
 }
 

--- a/internal/services/repository/resource_repository_go_proxy.go
+++ b/internal/services/repository/resource_repository_go_proxy.go
@@ -167,6 +167,13 @@ func resourceGoProxyRepositoryRead(resourceData *schema.ResourceData, m interfac
 		return nil
 	}
 
+	expectedRoutingRule := resourceData.Get("routing_rule").(string)
+	if repo.RoutingRule != nil && *repo.RoutingRule != expectedRoutingRule {
+		resourceData.Set("routing_rule", *repo.RoutingRule)
+	} else if repo.RoutingRule == nil {
+		resourceData.Set("routing_rule", nil)
+	}
+
 	return setGoProxyRepositoryToResourceData(repo, resourceData)
 }
 

--- a/internal/services/repository/resource_repository_helm_proxy.go
+++ b/internal/services/repository/resource_repository_helm_proxy.go
@@ -167,6 +167,13 @@ func resourceHelmProxyRepositoryRead(resourceData *schema.ResourceData, m interf
 		return nil
 	}
 
+	expectedRoutingRule := resourceData.Get("routing_rule").(string)
+	if repo.RoutingRule != nil && *repo.RoutingRule != expectedRoutingRule {
+		resourceData.Set("routing_rule", *repo.RoutingRule)
+	} else if repo.RoutingRule == nil {
+		resourceData.Set("routing_rule", nil)
+	}
+
 	return setHelmProxyRepositoryToResourceData(repo, resourceData)
 }
 

--- a/internal/services/repository/resource_repository_maven_proxy.go
+++ b/internal/services/repository/resource_repository_maven_proxy.go
@@ -188,6 +188,13 @@ func resourceMavenProxyRepositoryRead(resourceData *schema.ResourceData, m inter
 		return nil
 	}
 
+	expectedRoutingRule := resourceData.Get("routing_rule").(string)
+	if repo.RoutingRule != nil && *repo.RoutingRule != expectedRoutingRule {
+		resourceData.Set("routing_rule", *repo.RoutingRule)
+	} else if repo.RoutingRule == nil {
+		resourceData.Set("routing_rule", nil)
+	}
+
 	return setMavenProxyRepositoryToResourceData(repo, resourceData)
 }
 

--- a/internal/services/repository/resource_repository_npm_proxy.go
+++ b/internal/services/repository/resource_repository_npm_proxy.go
@@ -187,6 +187,13 @@ func resourceNpmProxyRepositoryRead(resourceData *schema.ResourceData, m interfa
 		return nil
 	}
 
+	expectedRoutingRule := resourceData.Get("routing_rule").(string)
+	if repo.RoutingRule != nil && *repo.RoutingRule != expectedRoutingRule {
+		resourceData.Set("routing_rule", *repo.RoutingRule)
+	} else if repo.RoutingRule == nil {
+		resourceData.Set("routing_rule", nil)
+	}
+
 	return setNpmProxyRepositoryToResourceData(repo, resourceData)
 }
 

--- a/internal/services/repository/resource_repository_nuget_proxy.go
+++ b/internal/services/repository/resource_repository_nuget_proxy.go
@@ -185,6 +185,13 @@ func resourceNugetProxyRepositoryRead(resourceData *schema.ResourceData, m inter
 		return nil
 	}
 
+	expectedRoutingRule := resourceData.Get("routing_rule").(string)
+	if repo.RoutingRule != nil && *repo.RoutingRule != expectedRoutingRule {
+		resourceData.Set("routing_rule", *repo.RoutingRule)
+	} else if repo.RoutingRule == nil {
+		resourceData.Set("routing_rule", nil)
+	}
+
 	return setNugetProxyRepositoryToResourceData(repo, resourceData)
 }
 

--- a/internal/services/repository/resource_repository_p2_proxy.go
+++ b/internal/services/repository/resource_repository_p2_proxy.go
@@ -180,6 +180,13 @@ func resourceP2ProxyRepositoryUpdate(resourceData *schema.ResourceData, m interf
 		return err
 	}
 
+	expectedRoutingRule := resourceData.Get("routing_rule").(string)
+	if repo.RoutingRule != nil && *repo.RoutingRule != expectedRoutingRule {
+		resourceData.Set("routing_rule", *repo.RoutingRule)
+	} else if repo.RoutingRule == nil {
+		resourceData.Set("routing_rule", nil)
+	}
+
 	return resourceP2ProxyRepositoryRead(resourceData, m)
 }
 

--- a/internal/services/repository/resource_repository_pypi_proxy.go
+++ b/internal/services/repository/resource_repository_pypi_proxy.go
@@ -167,6 +167,13 @@ func resourcePypiProxyRepositoryRead(resourceData *schema.ResourceData, m interf
 		return nil
 	}
 
+	expectedRoutingRule := resourceData.Get("routing_rule").(string)
+	if repo.RoutingRule != nil && *repo.RoutingRule != expectedRoutingRule {
+		resourceData.Set("routing_rule", *repo.RoutingRule)
+	} else if repo.RoutingRule == nil {
+		resourceData.Set("routing_rule", nil)
+	}
+
 	return setPypiProxyRepositoryToResourceData(repo, resourceData)
 }
 

--- a/internal/services/repository/resource_repository_r_proxy.go
+++ b/internal/services/repository/resource_repository_r_proxy.go
@@ -156,7 +156,6 @@ func resourceRProxyRepositoryCreate(resourceData *schema.ResourceData, m interfa
 
 func resourceRProxyRepositoryRead(resourceData *schema.ResourceData, m interface{}) error {
 	client := m.(*nexus.NexusClient)
-
 	repo, err := client.Repository.R.Proxy.Get(resourceData.Id())
 	if err != nil {
 		return err
@@ -165,6 +164,13 @@ func resourceRProxyRepositoryRead(resourceData *schema.ResourceData, m interface
 	if repo == nil {
 		resourceData.SetId("")
 		return nil
+	}
+
+	expectedRoutingRule := resourceData.Get("routing_rule").(string)
+	if repo.RoutingRule != nil && *repo.RoutingRule != expectedRoutingRule {
+		resourceData.Set("routing_rule", *repo.RoutingRule)
+	} else if repo.RoutingRule == nil {
+		resourceData.Set("routing_rule", nil)
 	}
 
 	return setRProxyRepositoryToResourceData(repo, resourceData)

--- a/internal/services/repository/resource_repository_raw_proxy.go
+++ b/internal/services/repository/resource_repository_raw_proxy.go
@@ -167,6 +167,13 @@ func resourceRawProxyRepositoryRead(resourceData *schema.ResourceData, m interfa
 		return nil
 	}
 
+	expectedRoutingRule := resourceData.Get("routing_rule").(string)
+	if repo.RoutingRule != nil && *repo.RoutingRule != expectedRoutingRule {
+		resourceData.Set("routing_rule", *repo.RoutingRule)
+	} else if repo.RoutingRule == nil {
+		resourceData.Set("routing_rule", nil)
+	}
+
 	return setRawProxyRepositoryToResourceData(repo, resourceData)
 }
 

--- a/internal/services/repository/resource_repository_rubygems_proxy.go
+++ b/internal/services/repository/resource_repository_rubygems_proxy.go
@@ -167,6 +167,13 @@ func resourceRubygemsProxyRepositoryRead(resourceData *schema.ResourceData, m in
 		return nil
 	}
 
+	expectedRoutingRule := resourceData.Get("routing_rule").(string)
+	if repo.RoutingRule != nil && *repo.RoutingRule != expectedRoutingRule {
+		resourceData.Set("routing_rule", *repo.RoutingRule)
+	} else if repo.RoutingRule == nil {
+		resourceData.Set("routing_rule", nil)
+	}
+
 	return setRubygemsProxyRepositoryToResourceData(repo, resourceData)
 }
 

--- a/internal/services/repository/resource_repository_yum_proxy.go
+++ b/internal/services/repository/resource_repository_yum_proxy.go
@@ -194,6 +194,13 @@ func resourceYumProxyRepositoryUpdate(resourceData *schema.ResourceData, m inter
 		return err
 	}
 
+	expectedRoutingRule := resourceData.Get("routing_rule").(string)
+	if repo.RoutingRule != nil && *repo.RoutingRule != expectedRoutingRule {
+		resourceData.Set("routing_rule", *repo.RoutingRule)
+	} else if repo.RoutingRule == nil {
+		resourceData.Set("routing_rule", nil)
+	}
+
 	return resourceYumProxyRepositoryRead(resourceData, m)
 }
 


### PR DESCRIPTION
This PR aims to fix #397.

I have tested:

-  creation of new repo with a routing rule specified
-  applying after a manual modification of the routing rule using the UI
-  tested with multiple kind of repos (proxy all of them since routing rules are only for proxy repos)

This is the output of an apply when the routing rule is manually modified:
```
nexus_repository_r_proxy.cran_mirror: Refreshing state... [id=cran-mirror]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # nexus_repository_r_proxy.cran_mirror will be updated in-place
  ~ resource "nexus_repository_r_proxy" "cran_mirror" {
        id           = "cran-mirror"
        name         = "cran-mirror"
      + routing_rule = "allow_cran"
        # (1 unchanged attribute hidden)

        # (4 unchanged blocks hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

nexus_repository_r_proxy.cran_mirror: Modifying... [id=cran-mirror]
nexus_repository_r_proxy.cran_mirror: Modifications complete after 0s [id=cran-mirror]

Apply complete! Resources: 0 added, 1 changed, 0 destroyed.
```