### PR TITLE
fix: refreshing ldap group_type

### DIFF
--- a/docs/resources/security_ldap.md
+++ b/docs/resources/security_ldap.md
@@ -48,7 +48,7 @@ resource "nexus_security_ldap" "example" {
 - `auth_username` (String) This must be a fully qualified username if simple authentication is used. Required if authScheme other than none.
 - `connection_retry_delay_seconds` (Number) How long to wait before retrying
 - `connection_timeout_seconds` (Number) How long to wait before timeout
-- `group_type` (String) Defines a type of groups used: static (a group contains a list of users) or dynamic (a user contains a list of groups). Required if ldapGroupsAsRoles is true.
+- `group_type` (String) Defines a type of groups used: static (a group contains a list of users) or dynamic (a user contains a list of groups). Required if ldapGroupsAsRoles is true. This must be set in upper case.
 - `host` (String) LDAP server connection hostname
 - `max_incident_count` (Number) How many retry attempts
 - `name` (String) LDAP server name

--- a/internal/services/security/resource_security_ldap.go
+++ b/internal/services/security/resource_security_ldap.go
@@ -89,7 +89,7 @@ func ResourceSecurityLDAP() *schema.Resource {
 				Description:  "Defines a type of groups used: static (a group contains a list of users) or dynamic (a user contains a list of groups). Required if ldapGroupsAsRoles is true.",
 				Required:     true,
 				Type:         schema.TypeString,
-				ValidateFunc: validation.StringInSlice([]string{"dynamic", "static"}, false),
+				ValidateFunc: validation.StringInSlice([]string{"DYNAMIC", "STATIC"}, false),
 			},
 			"host": {
 				Description: "LDAP server connection hostname",
@@ -250,7 +250,7 @@ func setSecurityLDAPToResourceData(ldap *security.LDAP, d *schema.ResourceData) 
 	d.Set("group_member_format", ldap.GroupMemberFormat)
 	d.Set("group_object_class", ldap.GroupObjectClass)
 	d.Set("group_subtree", ldap.GroupSubtree)
-	// d.Set("group_type", ldap.GroupType) // GroupType is not returned by API :-/
+	d.Set("group_type", ldap.GroupType)
 	d.Set("host", ldap.Host)
 	d.Set("ldap_groups_as_roles", ldap.LDAPGroupsAsRoles)
 	d.Set("max_incident_count", ldap.MaxIncidentCount)


### PR DESCRIPTION
This PR aims to read the ldap group_type from Nexus API since it is available in latest Nexus versions.

I am trying to force the uppercase usage since the Nexus API returns the value in upper case.

Error sample if the group_type is set in lowercase 
```
edu@edu-ThinkPad-T470s:~/Git/terraform-product$ terraform apply
╷
│ Error: expected group_type to be one of ["DYNAMIC" "STATIC"], got dynamic
│ 
│   with nexus_security_ldap.server1,
│   on main.tf line 34, in resource "nexus_security_ldap" "server1":
│   34:   group_type                     = "dynamic"
│ 
╵
```

Successful sample if group_type is set in uppercase

```
edu@edu-ThinkPad-T470s:~/Git/terraform-product$ terraform apply

Terraform used the selected providers to generate the following execution plan. Resource
actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # nexus_security_ldap.server1 will be created
  + resource "nexus_security_ldap" "server1" {
      + auth_password                  = (sensitive value)
      + auth_schema                    = "SIMPLE"
      + auth_username                  = "user@contoso.com"
      + connection_retry_delay_seconds = 300
      + connection_timeout_seconds     = 30
      + group_subtree                  = false
      + group_type                     = "DYNAMIC"
      + host                           = "169.254.169.254"
      + id                             = (known after apply)
      + ldap_groups_as_roles           = true
      + max_incident_count             = 3
      + name                           = "server1"
      + port                           = 389
      + protocol                       = "LDAP"
      + search_base                    = "dc=contoso,DC=com"
      + user_base_dn                   = "ou=DomainUsers"
      + user_email_address_attribute   = "userPrincipalName"
      + user_id_attribute              = "sAMAccountName"
      + user_member_of_attribute       = "memberOf"
      + user_object_class              = "user"
      + user_real_name_attribute       = "cn"
      + user_subtree                   = true
    }

Plan: 1 to add, 0 to change, 0 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

nexus_security_ldap.server1: Creating...
nexus_security_ldap.server1: Creation complete after 0s [id=server1]

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
edu@edu-ThinkPad-T470s:~/Git/terraform-product$ terraform apply
nexus_security_ldap.server1: Refreshing state... [id=server1]

No changes. Your infrastructure matches the configuration.

Terraform has compared your real infrastructure against your configuration and found no
differences, so no changes are needed.

Apply complete! Resources: 0 added, 0 changed, 0 destroyed.
```