### PR TITLE
fix: Remove default boolean set for user_agent_suffix

### DIFF
--- a/internal/schema/repository/schema_http_client.go
+++ b/internal/schema/repository/schema_http_client.go
@@ -112,7 +112,6 @@ var (
 					Description: "Custom fragment to append to User-Agent header in HTTP requests",
 					Optional:    true,
 					Type:        schema.TypeString,
-					Default:     false,
 				},
 				"use_trust_store": {
 					Description: "Use certificates stored in the Nexus Repository Manager truststore to connect to external systems",


### PR DESCRIPTION
user_agent_suffix is an optional string, however, it currently has a default boolean set to false. This causes the provider to set this attribute as "0" if it is not provided.

This change closes #541