### PR TITLE
fix: prevent int64 overflow panic when Nexus returns MaxInt64 for blobstore sizes

### DIFF
--- a/internal/services/blobstore/flatten.go
+++ b/internal/services/blobstore/flatten.go
@@ -1,9 +1,22 @@
 package blobstore
 
 import (
+	"math"
+
 	"github.com/datadrivers/go-nexus-client/nexus3/schema/blobstore"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
+
+// sanitizeBlobstoreInt returns 0 when v equals math.MaxInt, which Nexus uses as a
+// sentinel for "unlimited" or "not yet calculated". Storing MaxInt64 in Terraform
+// state causes a ParseInt overflow panic because JSON serialises it as float64,
+// and the nearest float64 (9223372036854776000) exceeds MaxInt64.
+func sanitizeBlobstoreInt(v int) int {
+	if v == math.MaxInt {
+		return 0
+	}
+	return v
+}
 
 func flattenSoftQuota(softQuota *blobstore.SoftQuota) []map[string]interface{} {
 	if softQuota == nil {

--- a/internal/services/blobstore/resource_blobstore_azure.go
+++ b/internal/services/blobstore/resource_blobstore_azure.go
@@ -153,10 +153,10 @@ func resourceBlobstoreAzureRead(resourceData *schema.ResourceData, m interface{}
 	if err := resourceData.Set("name", bs.Name); err != nil {
 		return err
 	}
-	if err := resourceData.Set("blob_count", genericBlobstoreInformation.BlobCount); err != nil {
+	if err := resourceData.Set("blob_count", sanitizeBlobstoreInt(genericBlobstoreInformation.BlobCount)); err != nil {
 		return err
 	}
-	if err := resourceData.Set("total_size_in_bytes", genericBlobstoreInformation.TotalSizeInBytes); err != nil {
+	if err := resourceData.Set("total_size_in_bytes", sanitizeBlobstoreInt(genericBlobstoreInformation.TotalSizeInBytes)); err != nil {
 		return err
 	}
 	if err := resourceData.Set("bucket_configuration", flattenAzureBucketConfiguration(&bs.BucketConfiguration, resourceData)); err != nil {

--- a/internal/services/blobstore/resource_blobstore_file.go
+++ b/internal/services/blobstore/resource_blobstore_file.go
@@ -104,10 +104,10 @@ func resourceBlobstoreFileRead(resourceData *schema.ResourceData, m interface{})
 		return nil
 	}
 
-	if err := resourceData.Set("available_space_in_bytes", genericBlobstoreInformation.AvailableSpaceInBytes); err != nil {
+	if err := resourceData.Set("available_space_in_bytes", sanitizeBlobstoreInt(genericBlobstoreInformation.AvailableSpaceInBytes)); err != nil {
 		return err
 	}
-	if err := resourceData.Set("blob_count", genericBlobstoreInformation.BlobCount); err != nil {
+	if err := resourceData.Set("blob_count", sanitizeBlobstoreInt(genericBlobstoreInformation.BlobCount)); err != nil {
 		return err
 	}
 	if err := resourceData.Set("name", bs.Name); err != nil {
@@ -116,7 +116,7 @@ func resourceBlobstoreFileRead(resourceData *schema.ResourceData, m interface{})
 	if err := resourceData.Set("path", bs.Path); err != nil {
 		return err
 	}
-	if err := resourceData.Set("total_size_in_bytes", genericBlobstoreInformation.TotalSizeInBytes); err != nil {
+	if err := resourceData.Set("total_size_in_bytes", sanitizeBlobstoreInt(genericBlobstoreInformation.TotalSizeInBytes)); err != nil {
 		return err
 	}
 

--- a/internal/services/blobstore/resource_blobstore_group.go
+++ b/internal/services/blobstore/resource_blobstore_group.go
@@ -116,10 +116,10 @@ func resourceBlobstoreGroupRead(resourceData *schema.ResourceData, m interface{}
 		return nil
 	}
 
-	if err := resourceData.Set("available_space_in_bytes", genericBlobstoreInformation.AvailableSpaceInBytes); err != nil {
+	if err := resourceData.Set("available_space_in_bytes", sanitizeBlobstoreInt(genericBlobstoreInformation.AvailableSpaceInBytes)); err != nil {
 		return err
 	}
-	if err := resourceData.Set("blob_count", genericBlobstoreInformation.BlobCount); err != nil {
+	if err := resourceData.Set("blob_count", sanitizeBlobstoreInt(genericBlobstoreInformation.BlobCount)); err != nil {
 		return err
 	}
 	if err := resourceData.Set("fill_policy", string(bs.FillPolicy)); err != nil {
@@ -131,7 +131,7 @@ func resourceBlobstoreGroupRead(resourceData *schema.ResourceData, m interface{}
 	if err := resourceData.Set("name", bs.Name); err != nil {
 		return err
 	}
-	if err := resourceData.Set("total_size_in_bytes", genericBlobstoreInformation.TotalSizeInBytes); err != nil {
+	if err := resourceData.Set("total_size_in_bytes", sanitizeBlobstoreInt(genericBlobstoreInformation.TotalSizeInBytes)); err != nil {
 		return err
 	}
 

--- a/internal/services/blobstore/resource_blobstore_s3.go
+++ b/internal/services/blobstore/resource_blobstore_s3.go
@@ -273,10 +273,10 @@ func resourceBlobstoreS3Read(resourceData *schema.ResourceData, m interface{}) e
 	if err := resourceData.Set("name", bs.Name); err != nil {
 		return err
 	}
-	if err := resourceData.Set("blob_count", genericBlobstoreInformation.BlobCount); err != nil {
+	if err := resourceData.Set("blob_count", sanitizeBlobstoreInt(genericBlobstoreInformation.BlobCount)); err != nil {
 		return err
 	}
-	if err := resourceData.Set("total_size_in_bytes", genericBlobstoreInformation.TotalSizeInBytes); err != nil {
+	if err := resourceData.Set("total_size_in_bytes", sanitizeBlobstoreInt(genericBlobstoreInformation.TotalSizeInBytes)); err != nil {
 		return err
 	}
 	if err := resourceData.Set("bucket_configuration", flattenS3BucketConfiguration(&bs.BucketConfiguration, resourceData)); err != nil {


### PR DESCRIPTION
Uses math.MaxInt64 as a sentinel for "unlimited" or "not yet calculated" on available_space_in_bytes, total_size_in_bytes, and blob_count fields. 

When this value is written to Terraform state it is serialised as JSON float64, and the nearest representable float64 (9223372036854776000) exceeds MaxInt64. On the next plan Terraform reads this string back via strconv.ParseInt, which overflows and crashes the provider with "value out of range".

Sanitise the sentinel before writing to state by mapping MaxInt64 → 0, applied consistently across all four blobstore resource read functions(file, group, s3, azure).
