### PR TITLE
feat: add repository read retry helper for HA propagation delays

### DIFF
--- a/internal/services/repository/helper_repository_read.go
+++ b/internal/services/repository/helper_repository_read.go
@@ -1,0 +1,30 @@
+package repository
+
+import (
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+const repositoryReadMaxAttempts = 10
+
+var repositoryReadRetryDelay = 30 * time.Second
+
+type repositoryReadFunc func(*schema.ResourceData, interface{}) error
+
+func retryRepositoryRead(read repositoryReadFunc, resourceData *schema.ResourceData, m interface{}) error {
+	var err error
+
+	for attempt := 1; attempt <= repositoryReadMaxAttempts; attempt++ {
+		err = read(resourceData, m)
+		if err == nil {
+			return nil
+		}
+
+		if attempt < repositoryReadMaxAttempts {
+			time.Sleep(repositoryReadRetryDelay)
+		}
+	}
+
+	return err
+}

--- a/internal/services/repository/helper_repository_read_test.go
+++ b/internal/services/repository/helper_repository_read_test.go
@@ -1,0 +1,54 @@
+package repository
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRetryRepositoryRead(t *testing.T) {
+	t.Run("returns immediately on success", func(t *testing.T) {
+		calls := 0
+		err := retryRepositoryRead(func(*schema.ResourceData, interface{}) error {
+			calls++
+			return nil
+		}, nil, nil)
+		assert.NoError(t, err)
+		assert.Equal(t, 1, calls)
+	})
+
+	t.Run("retries until success", func(t *testing.T) {
+		oldDelay := repositoryReadRetryDelay
+		repositoryReadRetryDelay = time.Millisecond
+		t.Cleanup(func() { repositoryReadRetryDelay = oldDelay })
+
+		calls := 0
+		err := retryRepositoryRead(func(*schema.ResourceData, interface{}) error {
+			calls++
+			if calls < 3 {
+				return errors.New("not ready")
+			}
+			return nil
+		}, nil, nil)
+		assert.NoError(t, err)
+		assert.Equal(t, 3, calls)
+	})
+
+	t.Run("returns last error after max attempts", func(t *testing.T) {
+		oldDelay := repositoryReadRetryDelay
+		repositoryReadRetryDelay = time.Millisecond
+		t.Cleanup(func() { repositoryReadRetryDelay = oldDelay })
+
+		expectedErr := errors.New("persistent failure")
+		calls := 0
+		err := retryRepositoryRead(func(*schema.ResourceData, interface{}) error {
+			calls++
+			return expectedErr
+		}, nil, nil)
+		assert.ErrorIs(t, err, expectedErr)
+		assert.Equal(t, repositoryReadMaxAttempts, calls)
+	})
+}

--- a/internal/services/repository/resource_repository_apt_hosted.go
+++ b/internal/services/repository/resource_repository_apt_hosted.go
@@ -171,7 +171,7 @@ func resourceAptHostedRepositoryCreate(resourceData *schema.ResourceData, m inte
 	}
 	resourceData.SetId(repo.Name)
 
-	return resourceAptHostedRepositoryRead(resourceData, m)
+	return retryRepositoryRead(resourceAptHostedRepositoryRead, resourceData, m)
 }
 
 func resourceAptHostedRepositoryRead(resourceData *schema.ResourceData, m interface{}) error {
@@ -200,7 +200,7 @@ func resourceAptHostedRepositoryUpdate(resourceData *schema.ResourceData, m inte
 		return err
 	}
 
-	return resourceAptHostedRepositoryRead(resourceData, m)
+	return retryRepositoryRead(resourceAptHostedRepositoryRead, resourceData, m)
 }
 
 func resourceAptHostedRepositoryDelete(resourceData *schema.ResourceData, m interface{}) error {

--- a/internal/services/repository/resource_repository_apt_proxy.go
+++ b/internal/services/repository/resource_repository_apt_proxy.go
@@ -170,7 +170,7 @@ func resourceAptProxyRepositoryCreate(resourceData *schema.ResourceData, m inter
 	}
 	resourceData.SetId(repo.Name)
 
-	return resourceAptProxyRepositoryRead(resourceData, m)
+	return retryRepositoryRead(resourceAptProxyRepositoryRead, resourceData, m)
 }
 
 func resourceAptProxyRepositoryRead(resourceData *schema.ResourceData, m interface{}) error {
@@ -199,7 +199,7 @@ func resourceAptProxyRepositoryUpdate(resourceData *schema.ResourceData, m inter
 		return err
 	}
 
-	return resourceAptProxyRepositoryRead(resourceData, m)
+	return retryRepositoryRead(resourceAptProxyRepositoryRead, resourceData, m)
 }
 
 func resourceAptProxyRepositoryDelete(resourceData *schema.ResourceData, m interface{}) error {

--- a/internal/services/repository/resource_repository_bower_group.go
+++ b/internal/services/repository/resource_repository_bower_group.go
@@ -85,7 +85,7 @@ func resourceBowerGroupRepositoryCreate(resourceData *schema.ResourceData, m int
 	}
 	resourceData.SetId(repo.Name)
 
-	return resourceBowerGroupRepositoryRead(resourceData, m)
+	return retryRepositoryRead(resourceBowerGroupRepositoryRead, resourceData, m)
 }
 
 func resourceBowerGroupRepositoryRead(resourceData *schema.ResourceData, m interface{}) error {
@@ -114,7 +114,7 @@ func resourceBowerGroupRepositoryUpdate(resourceData *schema.ResourceData, m int
 		return err
 	}
 
-	return resourceBowerGroupRepositoryRead(resourceData, m)
+	return retryRepositoryRead(resourceBowerGroupRepositoryRead, resourceData, m)
 }
 
 func resourceBowerGroupRepositoryDelete(resourceData *schema.ResourceData, m interface{}) error {

--- a/internal/services/repository/resource_repository_bower_hosted.go
+++ b/internal/services/repository/resource_repository_bower_hosted.go
@@ -112,7 +112,7 @@ func resourceBowerHostedRepositoryCreate(resourceData *schema.ResourceData, m in
 	}
 	resourceData.SetId(repo.Name)
 
-	return resourceBowerHostedRepositoryRead(resourceData, m)
+	return retryRepositoryRead(resourceBowerHostedRepositoryRead, resourceData, m)
 }
 
 func resourceBowerHostedRepositoryRead(resourceData *schema.ResourceData, m interface{}) error {
@@ -141,7 +141,7 @@ func resourceBowerHostedRepositoryUpdate(resourceData *schema.ResourceData, m in
 		return err
 	}
 
-	return resourceBowerHostedRepositoryRead(resourceData, m)
+	return retryRepositoryRead(resourceBowerHostedRepositoryRead, resourceData, m)
 }
 
 func resourceBowerHostedRepositoryDelete(resourceData *schema.ResourceData, m interface{}) error {

--- a/internal/services/repository/resource_repository_bower_proxy.go
+++ b/internal/services/repository/resource_repository_bower_proxy.go
@@ -167,7 +167,7 @@ func resourceBowerProxyRepositoryCreate(resourceData *schema.ResourceData, m int
 	}
 	resourceData.SetId(repo.Name)
 
-	return resourceBowerProxyRepositoryRead(resourceData, m)
+	return retryRepositoryRead(resourceBowerProxyRepositoryRead, resourceData, m)
 }
 
 func resourceBowerProxyRepositoryRead(resourceData *schema.ResourceData, m interface{}) error {
@@ -196,7 +196,7 @@ func resourceBowerProxyRepositoryUpdate(resourceData *schema.ResourceData, m int
 		return err
 	}
 
-	return resourceBowerProxyRepositoryRead(resourceData, m)
+	return retryRepositoryRead(resourceBowerProxyRepositoryRead, resourceData, m)
 }
 
 func resourceBowerProxyRepositoryDelete(resourceData *schema.ResourceData, m interface{}) error {

--- a/internal/services/repository/resource_repository_cargo_group.go
+++ b/internal/services/repository/resource_repository_cargo_group.go
@@ -86,7 +86,7 @@ func resourceCargoGroupRepositoryCreate(resourceData *schema.ResourceData, m int
 	}
 	resourceData.SetId(repo.Name)
 
-	return resourceCargoGroupRepositoryRead(resourceData, m)
+	return retryRepositoryRead(resourceCargoGroupRepositoryRead, resourceData, m)
 }
 
 func resourceCargoGroupRepositoryRead(resourceData *schema.ResourceData, m interface{}) error {
@@ -115,7 +115,7 @@ func resourceCargoGroupRepositoryUpdate(resourceData *schema.ResourceData, m int
 		return err
 	}
 
-	return resourceCargoGroupRepositoryRead(resourceData, m)
+	return retryRepositoryRead(resourceCargoGroupRepositoryRead, resourceData, m)
 }
 
 func resourceCargoGroupRepositoryDelete(resourceData *schema.ResourceData, m interface{}) error {

--- a/internal/services/repository/resource_repository_cargo_hosted.go
+++ b/internal/services/repository/resource_repository_cargo_hosted.go
@@ -113,7 +113,7 @@ func resourceCargoHostedRepositoryCreate(resourceData *schema.ResourceData, m in
 	}
 	resourceData.SetId(repo.Name)
 
-	return resourceCargoHostedRepositoryRead(resourceData, m)
+	return retryRepositoryRead(resourceCargoHostedRepositoryRead, resourceData, m)
 }
 
 func resourceCargoHostedRepositoryRead(resourceData *schema.ResourceData, m interface{}) error {
@@ -142,7 +142,7 @@ func resourceCargoHostedRepositoryUpdate(resourceData *schema.ResourceData, m in
 		return err
 	}
 
-	return resourceCargoHostedRepositoryRead(resourceData, m)
+	return retryRepositoryRead(resourceCargoHostedRepositoryRead, resourceData, m)
 }
 
 func resourceCargoHostedRepositoryDelete(resourceData *schema.ResourceData, m interface{}) error {

--- a/internal/services/repository/resource_repository_cargo_proxy.go
+++ b/internal/services/repository/resource_repository_cargo_proxy.go
@@ -163,7 +163,7 @@ func resourceCargoProxyRepositoryCreate(resourceData *schema.ResourceData, m int
 	}
 	resourceData.SetId(repo.Name)
 
-	return resourceCargoProxyRepositoryRead(resourceData, m)
+	return retryRepositoryRead(resourceCargoProxyRepositoryRead, resourceData, m)
 }
 
 func resourceCargoProxyRepositoryRead(resourceData *schema.ResourceData, m interface{}) error {
@@ -192,7 +192,7 @@ func resourceCargoProxyRepositoryUpdate(resourceData *schema.ResourceData, m int
 		return err
 	}
 
-	return resourceCargoProxyRepositoryRead(resourceData, m)
+	return retryRepositoryRead(resourceCargoProxyRepositoryRead, resourceData, m)
 }
 
 func resourceCargoProxyRepositoryDelete(resourceData *schema.ResourceData, m interface{}) error {

--- a/internal/services/repository/resource_repository_cocoapods_proxy.go
+++ b/internal/services/repository/resource_repository_cocoapods_proxy.go
@@ -153,7 +153,7 @@ func resourceCocoapodsProxyRepositoryCreate(resourceData *schema.ResourceData, m
 	}
 	resourceData.SetId(repo.Name)
 
-	return resourceCocoapodsProxyRepositoryRead(resourceData, m)
+	return retryRepositoryRead(resourceCocoapodsProxyRepositoryRead, resourceData, m)
 }
 
 func resourceCocoapodsProxyRepositoryRead(resourceData *schema.ResourceData, m interface{}) error {
@@ -182,7 +182,7 @@ func resourceCocoapodsProxyRepositoryUpdate(resourceData *schema.ResourceData, m
 		return err
 	}
 
-	return resourceCocoapodsProxyRepositoryRead(resourceData, m)
+	return retryRepositoryRead(resourceCocoapodsProxyRepositoryRead, resourceData, m)
 }
 
 func resourceCocoapodsProxyRepositoryDelete(resourceData *schema.ResourceData, m interface{}) error {

--- a/internal/services/repository/resource_repository_conan_proxy.go
+++ b/internal/services/repository/resource_repository_conan_proxy.go
@@ -153,7 +153,7 @@ func resourceConanProxyRepositoryCreate(resourceData *schema.ResourceData, m int
 	}
 	resourceData.SetId(repo.Name)
 
-	return resourceConanProxyRepositoryRead(resourceData, m)
+	return retryRepositoryRead(resourceConanProxyRepositoryRead, resourceData, m)
 }
 
 func resourceConanProxyRepositoryRead(resourceData *schema.ResourceData, m interface{}) error {
@@ -182,7 +182,7 @@ func resourceConanProxyRepositoryUpdate(resourceData *schema.ResourceData, m int
 		return err
 	}
 
-	return resourceConanProxyRepositoryRead(resourceData, m)
+	return retryRepositoryRead(resourceConanProxyRepositoryRead, resourceData, m)
 }
 
 func resourceConanProxyRepositoryDelete(resourceData *schema.ResourceData, m interface{}) error {

--- a/internal/services/repository/resource_repository_conda_proxy.go
+++ b/internal/services/repository/resource_repository_conda_proxy.go
@@ -153,7 +153,7 @@ func resourceCondaProxyRepositoryCreate(resourceData *schema.ResourceData, m int
 	}
 	resourceData.SetId(repo.Name)
 
-	return resourceCondaProxyRepositoryRead(resourceData, m)
+	return retryRepositoryRead(resourceCondaProxyRepositoryRead, resourceData, m)
 }
 
 func resourceCondaProxyRepositoryRead(resourceData *schema.ResourceData, m interface{}) error {
@@ -182,7 +182,7 @@ func resourceCondaProxyRepositoryUpdate(resourceData *schema.ResourceData, m int
 		return err
 	}
 
-	return resourceCondaProxyRepositoryRead(resourceData, m)
+	return retryRepositoryRead(resourceCondaProxyRepositoryRead, resourceData, m)
 }
 
 func resourceCondaProxyRepositoryDelete(resourceData *schema.ResourceData, m interface{}) error {

--- a/internal/services/repository/resource_repository_docker_group.go
+++ b/internal/services/repository/resource_repository_docker_group.go
@@ -120,7 +120,7 @@ func resourceDockerGroupRepositoryCreate(resourceData *schema.ResourceData, m in
 	}
 	resourceData.SetId(repo.Name)
 
-	return resourceDockerGroupRepositoryRead(resourceData, m)
+	return retryRepositoryRead(resourceDockerGroupRepositoryRead, resourceData, m)
 }
 
 func resourceDockerGroupRepositoryRead(resourceData *schema.ResourceData, m interface{}) error {
@@ -149,7 +149,7 @@ func resourceDockerGroupRepositoryUpdate(resourceData *schema.ResourceData, m in
 		return err
 	}
 
-	return resourceDockerGroupRepositoryRead(resourceData, m)
+	return retryRepositoryRead(resourceDockerGroupRepositoryRead, resourceData, m)
 }
 
 func resourceDockerGroupRepositoryDelete(resourceData *schema.ResourceData, m interface{}) error {

--- a/internal/services/repository/resource_repository_docker_hosted.go
+++ b/internal/services/repository/resource_repository_docker_hosted.go
@@ -145,7 +145,7 @@ func resourceDockerHostedRepositoryCreate(resourceData *schema.ResourceData, m i
 	}
 	resourceData.SetId(repo.Name)
 
-	return resourceDockerHostedRepositoryRead(resourceData, m)
+	return retryRepositoryRead(resourceDockerHostedRepositoryRead, resourceData, m)
 }
 
 func resourceDockerHostedRepositoryRead(resourceData *schema.ResourceData, m interface{}) error {
@@ -174,7 +174,7 @@ func resourceDockerHostedRepositoryUpdate(resourceData *schema.ResourceData, m i
 		return err
 	}
 
-	return resourceDockerHostedRepositoryRead(resourceData, m)
+	return retryRepositoryRead(resourceDockerHostedRepositoryRead, resourceData, m)
 }
 
 func resourceDockerHostedRepositoryDelete(resourceData *schema.ResourceData, m interface{}) error {

--- a/internal/services/repository/resource_repository_docker_proxy.go
+++ b/internal/services/repository/resource_repository_docker_proxy.go
@@ -247,7 +247,7 @@ func resourceDockerProxyRepositoryCreate(resourceData *schema.ResourceData, m in
 	}
 	resourceData.SetId(repo.Name)
 
-	return resourceDockerProxyRepositoryRead(resourceData, m)
+	return retryRepositoryRead(resourceDockerProxyRepositoryRead, resourceData, m)
 }
 
 func resourceDockerProxyRepositoryRead(resourceData *schema.ResourceData, m interface{}) error {
@@ -276,7 +276,7 @@ func resourceDockerProxyRepositoryUpdate(resourceData *schema.ResourceData, m in
 		return err
 	}
 
-	return resourceDockerProxyRepositoryRead(resourceData, m)
+	return retryRepositoryRead(resourceDockerProxyRepositoryRead, resourceData, m)
 }
 
 func resourceDockerProxyRepositoryDelete(resourceData *schema.ResourceData, m interface{}) error {

--- a/internal/services/repository/resource_repository_gitlfs_hosted.go
+++ b/internal/services/repository/resource_repository_gitlfs_hosted.go
@@ -109,7 +109,7 @@ func resourceGitlfsHostedRepositoryCreate(resourceData *schema.ResourceData, m i
 	}
 	resourceData.SetId(repo.Name)
 
-	return resourceGitlfsHostedRepositoryRead(resourceData, m)
+	return retryRepositoryRead(resourceGitlfsHostedRepositoryRead, resourceData, m)
 }
 
 func resourceGitlfsHostedRepositoryRead(resourceData *schema.ResourceData, m interface{}) error {
@@ -138,7 +138,7 @@ func resourceGitlfsHostedRepositoryUpdate(resourceData *schema.ResourceData, m i
 		return err
 	}
 
-	return resourceGitlfsHostedRepositoryRead(resourceData, m)
+	return retryRepositoryRead(resourceGitlfsHostedRepositoryRead, resourceData, m)
 }
 
 func resourceGitlfsHostedRepositoryDelete(resourceData *schema.ResourceData, m interface{}) error {

--- a/internal/services/repository/resource_repository_go_group.go
+++ b/internal/services/repository/resource_repository_go_group.go
@@ -82,7 +82,7 @@ func resourceGoGroupRepositoryCreate(resourceData *schema.ResourceData, m interf
 	}
 	resourceData.SetId(repo.Name)
 
-	return resourceGoGroupRepositoryRead(resourceData, m)
+	return retryRepositoryRead(resourceGoGroupRepositoryRead, resourceData, m)
 }
 
 func resourceGoGroupRepositoryRead(resourceData *schema.ResourceData, m interface{}) error {
@@ -111,7 +111,7 @@ func resourceGoGroupRepositoryUpdate(resourceData *schema.ResourceData, m interf
 		return err
 	}
 
-	return resourceGoGroupRepositoryRead(resourceData, m)
+	return retryRepositoryRead(resourceGoGroupRepositoryRead, resourceData, m)
 }
 
 func resourceGoGroupRepositoryDelete(resourceData *schema.ResourceData, m interface{}) error {

--- a/internal/services/repository/resource_repository_go_proxy.go
+++ b/internal/services/repository/resource_repository_go_proxy.go
@@ -153,7 +153,7 @@ func resourceGoProxyRepositoryCreate(resourceData *schema.ResourceData, m interf
 	}
 	resourceData.SetId(repo.Name)
 
-	return resourceGoProxyRepositoryRead(resourceData, m)
+	return retryRepositoryRead(resourceGoProxyRepositoryRead, resourceData, m)
 }
 
 func resourceGoProxyRepositoryRead(resourceData *schema.ResourceData, m interface{}) error {
@@ -182,7 +182,7 @@ func resourceGoProxyRepositoryUpdate(resourceData *schema.ResourceData, m interf
 		return err
 	}
 
-	return resourceGoProxyRepositoryRead(resourceData, m)
+	return retryRepositoryRead(resourceGoProxyRepositoryRead, resourceData, m)
 }
 
 func resourceGoProxyRepositoryDelete(resourceData *schema.ResourceData, m interface{}) error {

--- a/internal/services/repository/resource_repository_helm_hosted.go
+++ b/internal/services/repository/resource_repository_helm_hosted.go
@@ -109,7 +109,7 @@ func resourceHelmHostedRepositoryCreate(resourceData *schema.ResourceData, m int
 	}
 	resourceData.SetId(repo.Name)
 
-	return resourceHelmHostedRepositoryRead(resourceData, m)
+	return retryRepositoryRead(resourceHelmHostedRepositoryRead, resourceData, m)
 }
 
 func resourceHelmHostedRepositoryRead(resourceData *schema.ResourceData, m interface{}) error {
@@ -138,7 +138,7 @@ func resourceHelmHostedRepositoryUpdate(resourceData *schema.ResourceData, m int
 		return err
 	}
 
-	return resourceHelmHostedRepositoryRead(resourceData, m)
+	return retryRepositoryRead(resourceHelmHostedRepositoryRead, resourceData, m)
 }
 
 func resourceHelmHostedRepositoryDelete(resourceData *schema.ResourceData, m interface{}) error {

--- a/internal/services/repository/resource_repository_helm_proxy.go
+++ b/internal/services/repository/resource_repository_helm_proxy.go
@@ -153,7 +153,7 @@ func resourceHelmProxyRepositoryCreate(resourceData *schema.ResourceData, m inte
 	}
 	resourceData.SetId(repo.Name)
 
-	return resourceHelmProxyRepositoryRead(resourceData, m)
+	return retryRepositoryRead(resourceHelmProxyRepositoryRead, resourceData, m)
 }
 
 func resourceHelmProxyRepositoryRead(resourceData *schema.ResourceData, m interface{}) error {
@@ -182,7 +182,7 @@ func resourceHelmProxyRepositoryUpdate(resourceData *schema.ResourceData, m inte
 		return err
 	}
 
-	return resourceHelmProxyRepositoryRead(resourceData, m)
+	return retryRepositoryRead(resourceHelmProxyRepositoryRead, resourceData, m)
 }
 
 func resourceHelmProxyRepositoryDelete(resourceData *schema.ResourceData, m interface{}) error {

--- a/internal/services/repository/resource_repository_maven_group.go
+++ b/internal/services/repository/resource_repository_maven_group.go
@@ -81,7 +81,7 @@ func resourceMavenGroupRepositoryCreate(resourceData *schema.ResourceData, m int
 	}
 	resourceData.SetId(repo.Name)
 
-	return resourceMavenGroupRepositoryRead(resourceData, m)
+	return retryRepositoryRead(resourceMavenGroupRepositoryRead, resourceData, m)
 }
 
 func resourceMavenGroupRepositoryRead(resourceData *schema.ResourceData, m interface{}) error {
@@ -110,7 +110,7 @@ func resourceMavenGroupRepositoryUpdate(resourceData *schema.ResourceData, m int
 		return err
 	}
 
-	return resourceMavenGroupRepositoryRead(resourceData, m)
+	return retryRepositoryRead(resourceMavenGroupRepositoryRead, resourceData, m)
 }
 
 func resourceMavenGroupRepositoryDelete(resourceData *schema.ResourceData, m interface{}) error {

--- a/internal/services/repository/resource_repository_maven_hosted.go
+++ b/internal/services/repository/resource_repository_maven_hosted.go
@@ -125,7 +125,7 @@ func resourceMavenHostedRepositoryCreate(resourceData *schema.ResourceData, m in
 	}
 	resourceData.SetId(repo.Name)
 
-	return resourceMavenHostedRepositoryRead(resourceData, m)
+	return retryRepositoryRead(resourceMavenHostedRepositoryRead, resourceData, m)
 }
 
 func resourceMavenHostedRepositoryRead(resourceData *schema.ResourceData, m interface{}) error {
@@ -154,7 +154,7 @@ func resourceMavenHostedRepositoryUpdate(resourceData *schema.ResourceData, m in
 		return err
 	}
 
-	return resourceMavenHostedRepositoryRead(resourceData, m)
+	return retryRepositoryRead(resourceMavenHostedRepositoryRead, resourceData, m)
 }
 
 func resourceMavenHostedRepositoryDelete(resourceData *schema.ResourceData, m interface{}) error {

--- a/internal/services/repository/resource_repository_maven_proxy.go
+++ b/internal/services/repository/resource_repository_maven_proxy.go
@@ -174,7 +174,7 @@ func resourceMavenProxyRepositoryCreate(resourceData *schema.ResourceData, m int
 	}
 	resourceData.SetId(repo.Name)
 
-	return resourceMavenProxyRepositoryRead(resourceData, m)
+	return retryRepositoryRead(resourceMavenProxyRepositoryRead, resourceData, m)
 }
 
 func resourceMavenProxyRepositoryRead(resourceData *schema.ResourceData, m interface{}) error {
@@ -203,7 +203,7 @@ func resourceMavenProxyRepositoryUpdate(resourceData *schema.ResourceData, m int
 		return err
 	}
 
-	return resourceMavenProxyRepositoryRead(resourceData, m)
+	return retryRepositoryRead(resourceMavenProxyRepositoryRead, resourceData, m)
 }
 
 func resourceMavenProxyRepositoryDelete(resourceData *schema.ResourceData, m interface{}) error {

--- a/internal/services/repository/resource_repository_npm_group.go
+++ b/internal/services/repository/resource_repository_npm_group.go
@@ -87,7 +87,7 @@ func resourceNpmGroupRepositoryCreate(resourceData *schema.ResourceData, m inter
 	}
 	resourceData.SetId(repo.Name)
 
-	return resourceNpmGroupRepositoryRead(resourceData, m)
+	return retryRepositoryRead(resourceNpmGroupRepositoryRead, resourceData, m)
 }
 
 func resourceNpmGroupRepositoryRead(resourceData *schema.ResourceData, m interface{}) error {
@@ -116,7 +116,7 @@ func resourceNpmGroupRepositoryUpdate(resourceData *schema.ResourceData, m inter
 		return err
 	}
 
-	return resourceNpmGroupRepositoryRead(resourceData, m)
+	return retryRepositoryRead(resourceNpmGroupRepositoryRead, resourceData, m)
 }
 
 func resourceNpmGroupRepositoryDelete(resourceData *schema.ResourceData, m interface{}) error {

--- a/internal/services/repository/resource_repository_npm_hosted.go
+++ b/internal/services/repository/resource_repository_npm_hosted.go
@@ -109,7 +109,7 @@ func resourceNpmHostedRepositoryCreate(resourceData *schema.ResourceData, m inte
 	}
 	resourceData.SetId(repo.Name)
 
-	return resourceNpmHostedRepositoryRead(resourceData, m)
+	return retryRepositoryRead(resourceNpmHostedRepositoryRead, resourceData, m)
 }
 
 func resourceNpmHostedRepositoryRead(resourceData *schema.ResourceData, m interface{}) error {
@@ -138,7 +138,7 @@ func resourceNpmHostedRepositoryUpdate(resourceData *schema.ResourceData, m inte
 		return err
 	}
 
-	return resourceNpmHostedRepositoryRead(resourceData, m)
+	return retryRepositoryRead(resourceNpmHostedRepositoryRead, resourceData, m)
 }
 
 func resourceNpmHostedRepositoryDelete(resourceData *schema.ResourceData, m interface{}) error {

--- a/internal/services/repository/resource_repository_npm_proxy.go
+++ b/internal/services/repository/resource_repository_npm_proxy.go
@@ -174,7 +174,7 @@ func resourceNpmProxyRepositoryCreate(resourceData *schema.ResourceData, m inter
 	}
 	resourceData.SetId(repo.Name)
 
-	return resourceNpmProxyRepositoryRead(resourceData, m)
+	return retryRepositoryRead(resourceNpmProxyRepositoryRead, resourceData, m)
 }
 
 func resourceNpmProxyRepositoryRead(resourceData *schema.ResourceData, m interface{}) error {
@@ -203,7 +203,7 @@ func resourceNpmProxyRepositoryUpdate(resourceData *schema.ResourceData, m inter
 		return err
 	}
 
-	return resourceNpmProxyRepositoryRead(resourceData, m)
+	return retryRepositoryRead(resourceNpmProxyRepositoryRead, resourceData, m)
 }
 
 func resourceNpmProxyRepositoryDelete(resourceData *schema.ResourceData, m interface{}) error {

--- a/internal/services/repository/resource_repository_nuget_group.go
+++ b/internal/services/repository/resource_repository_nuget_group.go
@@ -82,7 +82,7 @@ func resourceNugetGroupRepositoryCreate(resourceData *schema.ResourceData, m int
 	}
 	resourceData.SetId(repo.Name)
 
-	return resourceNugetGroupRepositoryRead(resourceData, m)
+	return retryRepositoryRead(resourceNugetGroupRepositoryRead, resourceData, m)
 }
 
 func resourceNugetGroupRepositoryRead(resourceData *schema.ResourceData, m interface{}) error {
@@ -111,7 +111,7 @@ func resourceNugetGroupRepositoryUpdate(resourceData *schema.ResourceData, m int
 		return err
 	}
 
-	return resourceNugetGroupRepositoryRead(resourceData, m)
+	return retryRepositoryRead(resourceNugetGroupRepositoryRead, resourceData, m)
 }
 
 func resourceNugetGroupRepositoryDelete(resourceData *schema.ResourceData, m interface{}) error {

--- a/internal/services/repository/resource_repository_nuget_hosted.go
+++ b/internal/services/repository/resource_repository_nuget_hosted.go
@@ -109,7 +109,7 @@ func resourceNugetHostedRepositoryCreate(resourceData *schema.ResourceData, m in
 	}
 	resourceData.SetId(repo.Name)
 
-	return resourceNugetHostedRepositoryRead(resourceData, m)
+	return retryRepositoryRead(resourceNugetHostedRepositoryRead, resourceData, m)
 }
 
 func resourceNugetHostedRepositoryRead(resourceData *schema.ResourceData, m interface{}) error {
@@ -138,7 +138,7 @@ func resourceNugetHostedRepositoryUpdate(resourceData *schema.ResourceData, m in
 		return err
 	}
 
-	return resourceNugetHostedRepositoryRead(resourceData, m)
+	return retryRepositoryRead(resourceNugetHostedRepositoryRead, resourceData, m)
 }
 
 func resourceNugetHostedRepositoryDelete(resourceData *schema.ResourceData, m interface{}) error {

--- a/internal/services/repository/resource_repository_nuget_proxy.go
+++ b/internal/services/repository/resource_repository_nuget_proxy.go
@@ -171,7 +171,7 @@ func resourceNugetProxyRepositoryCreate(resourceData *schema.ResourceData, m int
 	}
 	resourceData.SetId(repo.Name)
 
-	return resourceNugetProxyRepositoryRead(resourceData, m)
+	return retryRepositoryRead(resourceNugetProxyRepositoryRead, resourceData, m)
 }
 
 func resourceNugetProxyRepositoryRead(resourceData *schema.ResourceData, m interface{}) error {
@@ -200,7 +200,7 @@ func resourceNugetProxyRepositoryUpdate(resourceData *schema.ResourceData, m int
 		return err
 	}
 
-	return resourceNugetProxyRepositoryRead(resourceData, m)
+	return retryRepositoryRead(resourceNugetProxyRepositoryRead, resourceData, m)
 }
 
 func resourceNugetProxyRepositoryDelete(resourceData *schema.ResourceData, m interface{}) error {

--- a/internal/services/repository/resource_repository_p2_proxy.go
+++ b/internal/services/repository/resource_repository_p2_proxy.go
@@ -153,7 +153,7 @@ func resourceP2ProxyRepositoryCreate(resourceData *schema.ResourceData, m interf
 	}
 	resourceData.SetId(repo.Name)
 
-	return resourceP2ProxyRepositoryRead(resourceData, m)
+	return retryRepositoryRead(resourceP2ProxyRepositoryRead, resourceData, m)
 }
 
 func resourceP2ProxyRepositoryRead(resourceData *schema.ResourceData, m interface{}) error {
@@ -182,7 +182,7 @@ func resourceP2ProxyRepositoryUpdate(resourceData *schema.ResourceData, m interf
 		return err
 	}
 
-	return resourceP2ProxyRepositoryRead(resourceData, m)
+	return retryRepositoryRead(resourceP2ProxyRepositoryRead, resourceData, m)
 }
 
 func resourceP2ProxyRepositoryDelete(resourceData *schema.ResourceData, m interface{}) error {

--- a/internal/services/repository/resource_repository_pypi_group.go
+++ b/internal/services/repository/resource_repository_pypi_group.go
@@ -82,7 +82,7 @@ func resourcePypiGroupRepositoryCreate(resourceData *schema.ResourceData, m inte
 	}
 	resourceData.SetId(repo.Name)
 
-	return resourcePypiGroupRepositoryRead(resourceData, m)
+	return retryRepositoryRead(resourcePypiGroupRepositoryRead, resourceData, m)
 }
 
 func resourcePypiGroupRepositoryRead(resourceData *schema.ResourceData, m interface{}) error {
@@ -111,7 +111,7 @@ func resourcePypiGroupRepositoryUpdate(resourceData *schema.ResourceData, m inte
 		return err
 	}
 
-	return resourcePypiGroupRepositoryRead(resourceData, m)
+	return retryRepositoryRead(resourcePypiGroupRepositoryRead, resourceData, m)
 }
 
 func resourcePypiGroupRepositoryDelete(resourceData *schema.ResourceData, m interface{}) error {

--- a/internal/services/repository/resource_repository_pypi_hosted.go
+++ b/internal/services/repository/resource_repository_pypi_hosted.go
@@ -109,7 +109,7 @@ func resourcePypiHostedRepositoryCreate(resourceData *schema.ResourceData, m int
 	}
 	resourceData.SetId(repo.Name)
 
-	return resourcePypiHostedRepositoryRead(resourceData, m)
+	return retryRepositoryRead(resourcePypiHostedRepositoryRead, resourceData, m)
 }
 
 func resourcePypiHostedRepositoryRead(resourceData *schema.ResourceData, m interface{}) error {
@@ -138,7 +138,7 @@ func resourcePypiHostedRepositoryUpdate(resourceData *schema.ResourceData, m int
 		return err
 	}
 
-	return resourcePypiHostedRepositoryRead(resourceData, m)
+	return retryRepositoryRead(resourcePypiHostedRepositoryRead, resourceData, m)
 }
 
 func resourcePypiHostedRepositoryDelete(resourceData *schema.ResourceData, m interface{}) error {

--- a/internal/services/repository/resource_repository_pypi_proxy.go
+++ b/internal/services/repository/resource_repository_pypi_proxy.go
@@ -153,7 +153,7 @@ func resourcePypiProxyRepositoryCreate(resourceData *schema.ResourceData, m inte
 	}
 	resourceData.SetId(repo.Name)
 
-	return resourcePypiProxyRepositoryRead(resourceData, m)
+	return retryRepositoryRead(resourcePypiProxyRepositoryRead, resourceData, m)
 }
 
 func resourcePypiProxyRepositoryRead(resourceData *schema.ResourceData, m interface{}) error {
@@ -182,7 +182,7 @@ func resourcePypiProxyRepositoryUpdate(resourceData *schema.ResourceData, m inte
 		return err
 	}
 
-	return resourcePypiProxyRepositoryRead(resourceData, m)
+	return retryRepositoryRead(resourcePypiProxyRepositoryRead, resourceData, m)
 }
 
 func resourcePypiProxyRepositoryDelete(resourceData *schema.ResourceData, m interface{}) error {

--- a/internal/services/repository/resource_repository_r_group.go
+++ b/internal/services/repository/resource_repository_r_group.go
@@ -82,7 +82,7 @@ func resourceRGroupRepositoryCreate(resourceData *schema.ResourceData, m interfa
 	}
 	resourceData.SetId(repo.Name)
 
-	return resourceRGroupRepositoryRead(resourceData, m)
+	return retryRepositoryRead(resourceRGroupRepositoryRead, resourceData, m)
 }
 
 func resourceRGroupRepositoryRead(resourceData *schema.ResourceData, m interface{}) error {
@@ -111,7 +111,7 @@ func resourceRGroupRepositoryUpdate(resourceData *schema.ResourceData, m interfa
 		return err
 	}
 
-	return resourceRGroupRepositoryRead(resourceData, m)
+	return retryRepositoryRead(resourceRGroupRepositoryRead, resourceData, m)
 }
 
 func resourceRGroupRepositoryDelete(resourceData *schema.ResourceData, m interface{}) error {

--- a/internal/services/repository/resource_repository_r_hosted.go
+++ b/internal/services/repository/resource_repository_r_hosted.go
@@ -109,7 +109,7 @@ func resourceRHostedRepositoryCreate(resourceData *schema.ResourceData, m interf
 	}
 	resourceData.SetId(repo.Name)
 
-	return resourceRHostedRepositoryRead(resourceData, m)
+	return retryRepositoryRead(resourceRHostedRepositoryRead, resourceData, m)
 }
 
 func resourceRHostedRepositoryRead(resourceData *schema.ResourceData, m interface{}) error {
@@ -138,7 +138,7 @@ func resourceRHostedRepositoryUpdate(resourceData *schema.ResourceData, m interf
 		return err
 	}
 
-	return resourceRHostedRepositoryRead(resourceData, m)
+	return retryRepositoryRead(resourceRHostedRepositoryRead, resourceData, m)
 }
 
 func resourceRHostedRepositoryDelete(resourceData *schema.ResourceData, m interface{}) error {

--- a/internal/services/repository/resource_repository_r_proxy.go
+++ b/internal/services/repository/resource_repository_r_proxy.go
@@ -153,7 +153,7 @@ func resourceRProxyRepositoryCreate(resourceData *schema.ResourceData, m interfa
 	}
 	resourceData.SetId(repo.Name)
 
-	return resourceRProxyRepositoryRead(resourceData, m)
+	return retryRepositoryRead(resourceRProxyRepositoryRead, resourceData, m)
 }
 
 func resourceRProxyRepositoryRead(resourceData *schema.ResourceData, m interface{}) error {
@@ -182,7 +182,7 @@ func resourceRProxyRepositoryUpdate(resourceData *schema.ResourceData, m interfa
 		return err
 	}
 
-	return resourceRProxyRepositoryRead(resourceData, m)
+	return retryRepositoryRead(resourceRProxyRepositoryRead, resourceData, m)
 }
 
 func resourceRProxyRepositoryDelete(resourceData *schema.ResourceData, m interface{}) error {

--- a/internal/services/repository/resource_repository_raw_group.go
+++ b/internal/services/repository/resource_repository_raw_group.go
@@ -82,7 +82,7 @@ func resourceRawGroupRepositoryCreate(resourceData *schema.ResourceData, m inter
 	}
 	resourceData.SetId(repo.Name)
 
-	return resourceRawGroupRepositoryRead(resourceData, m)
+	return retryRepositoryRead(resourceRawGroupRepositoryRead, resourceData, m)
 }
 
 func resourceRawGroupRepositoryRead(resourceData *schema.ResourceData, m interface{}) error {
@@ -111,7 +111,7 @@ func resourceRawGroupRepositoryUpdate(resourceData *schema.ResourceData, m inter
 		return err
 	}
 
-	return resourceRawGroupRepositoryRead(resourceData, m)
+	return retryRepositoryRead(resourceRawGroupRepositoryRead, resourceData, m)
 }
 
 func resourceRawGroupRepositoryDelete(resourceData *schema.ResourceData, m interface{}) error {

--- a/internal/services/repository/resource_repository_raw_hosted.go
+++ b/internal/services/repository/resource_repository_raw_hosted.go
@@ -109,7 +109,7 @@ func resourceRawHostedRepositoryCreate(resourceData *schema.ResourceData, m inte
 	}
 	resourceData.SetId(repo.Name)
 
-	return resourceRawHostedRepositoryRead(resourceData, m)
+	return retryRepositoryRead(resourceRawHostedRepositoryRead, resourceData, m)
 }
 
 func resourceRawHostedRepositoryRead(resourceData *schema.ResourceData, m interface{}) error {
@@ -138,7 +138,7 @@ func resourceRawHostedRepositoryUpdate(resourceData *schema.ResourceData, m inte
 		return err
 	}
 
-	return resourceRawHostedRepositoryRead(resourceData, m)
+	return retryRepositoryRead(resourceRawHostedRepositoryRead, resourceData, m)
 }
 
 func resourceRawHostedRepositoryDelete(resourceData *schema.ResourceData, m interface{}) error {

--- a/internal/services/repository/resource_repository_raw_proxy.go
+++ b/internal/services/repository/resource_repository_raw_proxy.go
@@ -153,7 +153,7 @@ func resourceRawProxyRepositoryCreate(resourceData *schema.ResourceData, m inter
 	}
 	resourceData.SetId(repo.Name)
 
-	return resourceRawProxyRepositoryRead(resourceData, m)
+	return retryRepositoryRead(resourceRawProxyRepositoryRead, resourceData, m)
 }
 
 func resourceRawProxyRepositoryRead(resourceData *schema.ResourceData, m interface{}) error {
@@ -182,7 +182,7 @@ func resourceRawProxyRepositoryUpdate(resourceData *schema.ResourceData, m inter
 		return err
 	}
 
-	return resourceRawProxyRepositoryRead(resourceData, m)
+	return retryRepositoryRead(resourceRawProxyRepositoryRead, resourceData, m)
 }
 
 func resourceRawProxyRepositoryDelete(resourceData *schema.ResourceData, m interface{}) error {

--- a/internal/services/repository/resource_repository_rubygems_group.go
+++ b/internal/services/repository/resource_repository_rubygems_group.go
@@ -82,7 +82,7 @@ func resourceRubygemsGroupRepositoryCreate(resourceData *schema.ResourceData, m 
 	}
 	resourceData.SetId(repo.Name)
 
-	return resourceRubygemsGroupRepositoryRead(resourceData, m)
+	return retryRepositoryRead(resourceRubygemsGroupRepositoryRead, resourceData, m)
 }
 
 func resourceRubygemsGroupRepositoryRead(resourceData *schema.ResourceData, m interface{}) error {
@@ -111,7 +111,7 @@ func resourceRubygemsGroupRepositoryUpdate(resourceData *schema.ResourceData, m 
 		return err
 	}
 
-	return resourceRubygemsGroupRepositoryRead(resourceData, m)
+	return retryRepositoryRead(resourceRubygemsGroupRepositoryRead, resourceData, m)
 }
 
 func resourceRubygemsGroupRepositoryDelete(resourceData *schema.ResourceData, m interface{}) error {

--- a/internal/services/repository/resource_repository_rubygems_hosted.go
+++ b/internal/services/repository/resource_repository_rubygems_hosted.go
@@ -109,7 +109,7 @@ func resourceRubygemsHostedRepositoryCreate(resourceData *schema.ResourceData, m
 	}
 	resourceData.SetId(repo.Name)
 
-	return resourceRubygemsHostedRepositoryRead(resourceData, m)
+	return retryRepositoryRead(resourceRubygemsHostedRepositoryRead, resourceData, m)
 }
 
 func resourceRubygemsHostedRepositoryRead(resourceData *schema.ResourceData, m interface{}) error {
@@ -138,7 +138,7 @@ func resourceRubygemsHostedRepositoryUpdate(resourceData *schema.ResourceData, m
 		return err
 	}
 
-	return resourceRubygemsHostedRepositoryRead(resourceData, m)
+	return retryRepositoryRead(resourceRubygemsHostedRepositoryRead, resourceData, m)
 }
 
 func resourceRubygemsHostedRepositoryDelete(resourceData *schema.ResourceData, m interface{}) error {

--- a/internal/services/repository/resource_repository_rubygems_proxy.go
+++ b/internal/services/repository/resource_repository_rubygems_proxy.go
@@ -153,7 +153,7 @@ func resourceRubygemsProxyRepositoryCreate(resourceData *schema.ResourceData, m 
 	}
 	resourceData.SetId(repo.Name)
 
-	return resourceRubygemsProxyRepositoryRead(resourceData, m)
+	return retryRepositoryRead(resourceRubygemsProxyRepositoryRead, resourceData, m)
 }
 
 func resourceRubygemsProxyRepositoryRead(resourceData *schema.ResourceData, m interface{}) error {
@@ -182,7 +182,7 @@ func resourceRubygemsProxyRepositoryUpdate(resourceData *schema.ResourceData, m 
 		return err
 	}
 
-	return resourceRubygemsProxyRepositoryRead(resourceData, m)
+	return retryRepositoryRead(resourceRubygemsProxyRepositoryRead, resourceData, m)
 }
 
 func resourceRubygemsProxyRepositoryDelete(resourceData *schema.ResourceData, m interface{}) error {

--- a/internal/services/repository/resource_repository_yum_group.go
+++ b/internal/services/repository/resource_repository_yum_group.go
@@ -97,7 +97,7 @@ func resourceYumGroupRepositoryCreate(resourceData *schema.ResourceData, m inter
 	}
 	resourceData.SetId(repo.Name)
 
-	return resourceYumGroupRepositoryRead(resourceData, m)
+	return retryRepositoryRead(resourceYumGroupRepositoryRead, resourceData, m)
 }
 
 func resourceYumGroupRepositoryRead(resourceData *schema.ResourceData, m interface{}) error {
@@ -126,7 +126,7 @@ func resourceYumGroupRepositoryUpdate(resourceData *schema.ResourceData, m inter
 		return err
 	}
 
-	return resourceYumGroupRepositoryRead(resourceData, m)
+	return retryRepositoryRead(resourceYumGroupRepositoryRead, resourceData, m)
 }
 
 func resourceYumGroupRepositoryDelete(resourceData *schema.ResourceData, m interface{}) error {

--- a/internal/services/repository/resource_repository_yum_hosted.go
+++ b/internal/services/repository/resource_repository_yum_hosted.go
@@ -132,7 +132,7 @@ func resourceYumHostedRepositoryCreate(resourceData *schema.ResourceData, m inte
 	}
 	resourceData.SetId(repo.Name)
 
-	return resourceYumHostedRepositoryRead(resourceData, m)
+	return retryRepositoryRead(resourceYumHostedRepositoryRead, resourceData, m)
 }
 
 func resourceYumHostedRepositoryRead(resourceData *schema.ResourceData, m interface{}) error {
@@ -161,7 +161,7 @@ func resourceYumHostedRepositoryUpdate(resourceData *schema.ResourceData, m inte
 		return err
 	}
 
-	return resourceYumHostedRepositoryRead(resourceData, m)
+	return retryRepositoryRead(resourceYumHostedRepositoryRead, resourceData, m)
 }
 
 func resourceYumHostedRepositoryDelete(resourceData *schema.ResourceData, m interface{}) error {

--- a/internal/services/repository/resource_repository_yum_proxy.go
+++ b/internal/services/repository/resource_repository_yum_proxy.go
@@ -167,7 +167,7 @@ func resourceYumProxyRepositoryCreate(resourceData *schema.ResourceData, m inter
 	}
 	resourceData.SetId(repo.Name)
 
-	return resourceYumProxyRepositoryRead(resourceData, m)
+	return retryRepositoryRead(resourceYumProxyRepositoryRead, resourceData, m)
 }
 
 func resourceYumProxyRepositoryRead(resourceData *schema.ResourceData, m interface{}) error {
@@ -196,7 +196,7 @@ func resourceYumProxyRepositoryUpdate(resourceData *schema.ResourceData, m inter
 		return err
 	}
 
-	return resourceYumProxyRepositoryRead(resourceData, m)
+	return retryRepositoryRead(resourceYumProxyRepositoryRead, resourceData, m)
 }
 
 func resourceYumProxyRepositoryDelete(resourceData *schema.ResourceData, m interface{}) error {


### PR DESCRIPTION
Closes: [593](https://github.com/datadrivers/terraform-provider-nexus/issues/593)

Background

Following the upgrade to version 3.93, repository changes are taking longer to propagate between pods in HA deployments. As the Terraform provider performs a read immediately after a create or update operation to populate state, requests can be routed to a pod that has not yet received the changes, resulting in transient 404 Not Found responses.

Solution

A reusable helper function has been introduced to retry repository read operations with a short delay between attempts, allowing time for repository changes to propagate across the cluster and mitigating transient 404 Not Found responses during state reconciliation.

```
package repository

import (
	"time"

	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
)

const repositoryReadMaxAttempts = 10

var repositoryReadRetryDelay = 30 * time.Second

type repositoryReadFunc func(*schema.ResourceData, interface{}) error

func retryRepositoryRead(read repositoryReadFunc, resourceData *schema.ResourceData, m interface{}) error {
	var err error

	for attempt := 1; attempt <= repositoryReadMaxAttempts; attempt++ {
		err = read(resourceData, m)
		if err == nil {
			return nil
		}

		if attempt < repositoryReadMaxAttempts {
			time.Sleep(repositoryReadRetryDelay)
		}
	}

	return err
}
```