### PR TITLE
fix(repository): guard nil Npm in npm_proxy read for Nexus 3.94.0

### DIFF
--- a/internal/services/repository/resource_repository_npm_proxy.go
+++ b/internal/services/repository/resource_repository_npm_proxy.go
@@ -153,8 +153,14 @@ func setNpmProxyRepositoryToResourceData(repo *repository.NpmProxyRepository, re
 		return err
 	}
 
-	resourceData.Set("remove_quarantined", repo.RemoveQuarantined)
-	resourceData.Set("remove_non_cataloged", repo.RemoveNonCataloged)
+	// Nexus >= 3.94.0 may omit `npm` in GET responses; guard nil to avoid panic.
+	if repo.Npm != nil {
+		resourceData.Set("remove_quarantined", repo.RemoveQuarantined)
+		resourceData.Set("remove_non_cataloged", repo.RemoveNonCataloged)
+	} else {
+		resourceData.Set("remove_quarantined", false)
+		resourceData.Set("remove_non_cataloged", false)
+	}
 
 	if repo.Cleanup != nil {
 		if err := resourceData.Set("cleanup", flattenCleanup(repo.Cleanup)); err != nil {

--- a/internal/services/repository/resource_repository_npm_proxy_unit_test.go
+++ b/internal/services/repository/resource_repository_npm_proxy_unit_test.go
@@ -1,0 +1,64 @@
+package repository
+
+import (
+	"testing"
+
+	"github.com/datadrivers/go-nexus-client/nexus3/schema/repository"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+// TestSetNpmProxyRepositoryToResourceData_NilNpm reproduces
+// https://github.com/datadrivers/terraform-provider-nexus/issues/596.
+//
+// Nexus Repository 3.94.0 stopped returning the `npm` sub-object in its GET
+// response for npm proxy repositories, so the anonymously embedded *Npm pointer
+// on NpmProxyRepository is nil. Before the nil-guard, reading the promoted
+// RemoveQuarantined / RemoveNonCataloged fields dereferenced that nil pointer
+// and panicked while refreshing state (terraform plan). This test asserts the
+// read succeeds and both attributes default to false.
+func TestSetNpmProxyRepositoryToResourceData_NilNpm(t *testing.T) {
+	repo := &repository.NpmProxyRepository{
+		Name:   "npm-official-registry",
+		Online: true,
+		Npm:    nil, // Nexus >= 3.94.0 no longer returns this sub-object
+	}
+
+	resourceData := schema.TestResourceDataRaw(t, ResourceRepositoryNpmProxy().Schema, map[string]interface{}{})
+
+	if err := setNpmProxyRepositoryToResourceData(repo, resourceData); err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+
+	if got := resourceData.Get("remove_quarantined").(bool); got {
+		t.Errorf("remove_quarantined = %v, want false", got)
+	}
+	if got := resourceData.Get("remove_non_cataloged").(bool); got {
+		t.Errorf("remove_non_cataloged = %v, want false", got)
+	}
+}
+
+// TestSetNpmProxyRepositoryToResourceData_WithNpm ensures the values from the
+// npm sub-object are still propagated when Nexus does return it (< 3.94.0).
+func TestSetNpmProxyRepositoryToResourceData_WithNpm(t *testing.T) {
+	repo := &repository.NpmProxyRepository{
+		Name:   "npm-official-registry",
+		Online: true,
+		Npm: &repository.Npm{
+			RemoveQuarantined:  true,
+			RemoveNonCataloged: true,
+		},
+	}
+
+	resourceData := schema.TestResourceDataRaw(t, ResourceRepositoryNpmProxy().Schema, map[string]interface{}{})
+
+	if err := setNpmProxyRepositoryToResourceData(repo, resourceData); err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+
+	if got := resourceData.Get("remove_quarantined").(bool); !got {
+		t.Errorf("remove_quarantined = %v, want true", got)
+	}
+	if got := resourceData.Get("remove_non_cataloged").(bool); !got {
+		t.Errorf("remove_non_cataloged = %v, want true", got)
+	}
+}


### PR DESCRIPTION
### :dart:  What

Adds a nil-guard around the promoted `RemoveQuarantined` / `RemoveNonCataloged`
field access in `setNpmProxyRepositoryToResourceData`
(`internal/services/repository/resource_repository_npm_proxy.go`), plus a unit
test covering both the nil and non-nil `Npm` cases.

### :thinking:  Why

Fixes #596. Nexus Repository **3.94.0** no longer includes the `npm` sub-object
in the GET response for `nexus_repository_npm_proxy` resources (3.93.2 always
returned it). `NpmProxyRepository` embeds `*Npm` as an anonymous pointer, so
`repo.RemoveQuarantined` / `repo.RemoveNonCataloged` implicitly dereference
`repo.Npm`. With the pointer now nil, any `terraform plan`/refresh of an
existing npm proxy repository panics:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation ...]
  ... setNpmProxyRepositoryToResourceData(...)
      resource_repository_npm_proxy.go:156
```

The panic also cascades into "plugin did not respond" errors for every other
resource being refreshed in the same run.

### :wrench:  How

The fix mirrors the existing `if repo.Cleanup != nil { ... }` idiom two lines
below in the same function — read the promoted fields only when `repo.Npm` is
non-nil, otherwise fall back to the schema defaults (`false`):

```go
if repo.Npm != nil {
    resourceData.Set("remove_quarantined", repo.RemoveQuarantined)
    resourceData.Set("remove_non_cataloged", repo.RemoveNonCataloged)
} else {
    resourceData.Set("remove_quarantined", false)
    resourceData.Set("remove_non_cataloged", false)
}
```

No API-client or schema changes are needed.

### :alembic:  Testing

- New unit test `TestSetNpmProxyRepositoryToResourceData_NilNpm` reproduces the
  panic on the current code and passes with the fix;
  `TestSetNpmProxyRepositoryToResourceData_WithNpm` confirms values still
  propagate when Nexus returns the sub-object.
  `go test ./internal/services/repository/ -run TestSetNpmProxyRepositoryToResourceData`
- Verified end-to-end against a live **Nexus 3.94.0** instance: `terraform import`
  + `terraform plan` of an existing `nexus_repository_npm_proxy` succeeds with no
  diff (stock v2.8.0 panics on the same operation).

### :link: References

- Fixes #596